### PR TITLE
Allocate starting resource IDs for Cameo

### DIFF
--- a/tools/gritsettings/resource_ids
+++ b/tools/gritsettings/resource_ids
@@ -217,4 +217,9 @@
   },
 
   # Resource ids starting at 31000 are reserved for projects built on Chromium.
+
+  "cameo/src/resources/cameo_resources.grd": {
+    "includes": [31000],
+    "structures": [31500],
+  },
 }


### PR DESCRIPTION
Cameo uses Chromium resource framework (grit/grd). To make sure Cameo resource IDs are unique cross Chromium components, it is required to add new starting resource IDs. 

Since Cameo is a project built on Chromium, allocate starting IDs from 31000.
