### PR TITLE
Add cameo path to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,5 +310,6 @@ v8.log
 /win8/metro_driver/metro_driver_version_resources.xml
 /x86-generic_out/
 /xcodebuild
+/cameo
 cscope.*
 Session.vim


### PR DESCRIPTION
Path cameo/ should be taken as gitignore for our forked chromium.

@darktears , please help review, thanks.
