### PR TITLE
Update new path for cameo_resources.grd.

### DIFF
--- a/tools/gritsettings/resource_ids
+++ b/tools/gritsettings/resource_ids
@@ -218,7 +218,7 @@
 
   # Resource ids starting at 31000 are reserved for projects built on Chromium.
 
-  "cameo/src/resources/cameo_resources.grd": {
+  "cameo/src/runtime/resources/cameo_resources.grd": {
     "includes": [31000],
     "structures": [31500],
   },


### PR DESCRIPTION
Because Hongbo initializes the code base for Runtime with new fold hierarchy, 
we need to update the cameo_resources.grd.
