### PR TITLE
Add "messages" to generate resource id for string.

### DIFF
--- a/tools/gritsettings/resource_ids
+++ b/tools/gritsettings/resource_ids
@@ -221,5 +221,6 @@
   "cameo/src/runtime/resources/cameo_resources.grd": {
     "includes": [31000],
     "structures": [31500],
+    "messages": [32000],
   },
 }


### PR DESCRIPTION
This patch should work together with the patch "javascript dialog support" of cameo repo.
