### PR TITLE
Allow favicon image to be downloaded from file:// scheme URL

### DIFF
--- a/webkit/glue/multi_resolution_image_resource_fetcher.cc
+++ b/webkit/glue/multi_resolution_image_resource_fetcher.cc
@@ -41,7 +41,9 @@ void MultiResolutionImageResourceFetcher::OnURLFetchComplete(
     const WebURLResponse& response,
     const std::string& data) {
   std::vector<SkBitmap> bitmaps;
-  if (!response.isNull() && response.httpStatusCode() == 200) {
+  GURL url = static_cast<GURL>(response.url());
+  if (!response.isNull() &&
+      (response.httpStatusCode() == 200 || url.SchemeIsFile())) {
     // Request succeeded, try to convert it to an image.
     bitmaps = ImageDecoder::DecodeAll(
         reinterpret_cast<const unsigned char*>(data.data()), data.size());


### PR DESCRIPTION
Note this patch is also uploaded to upstream:
https://codereview.chromium.org/16358002/

Once it gets landed to upstream, this patch can be safely removed.

BUG=http://code.google.com/p/chromium/issues/detail?id=246511
TEST=Manual
