### PR TITLE
Enable touch-initiated HTML5 drag-drop on Windows

### DIFF
--- a/content/browser/renderer_host/render_widget_host_view_win.h
+++ b/content/browser/renderer_host/render_widget_host_view_win.h
@@ -285,6 +285,9 @@ class RenderWidgetHostViewWin
   virtual void ExtendSelectionAndDelete(size_t before, size_t after) OVERRIDE;
   virtual void EnsureCaretInRect(const gfx::Rect& rect) OVERRIDE;
 
+  bool in_long_press_gesture() const { return in_long_press_gesture_; }
+  void CancelLongPressGesture() { in_long_press_gesture_ = false; }
+
  protected:
   friend class RenderWidgetHostView;
 
@@ -594,6 +597,10 @@ class RenderWidgetHostViewWin
 
   // The OS-provided default IAccessible instance for our hwnd.
   base::win::ScopedComPtr<IAccessible> window_iaccessible_;
+
+  // True if the long press gesture is forwarded to renderer process and still
+  // in a valid status, e.g. no mouse up event happens.
+  bool in_long_press_gesture_;
 
   DISALLOW_COPY_AND_ASSIGN(RenderWidgetHostViewWin);
 };

--- a/content/browser/web_contents/web_contents_drag_win.h
+++ b/content/browser/web_contents/web_contents_drag_win.h
@@ -91,6 +91,9 @@ class CONTENT_EXPORT WebContentsDragWin
   void EndDragging();
   void CloseThread();
 
+  // Programmatically send mouse down event for touch-initiated drag and drop.
+  void SendMouseEventForTouchDnD();
+
   // For debug check only. Access only on drag-and-drop thread.
   base::PlatformThreadId drag_drop_thread_id_;
 

--- a/content/browser/web_contents/web_drag_source_win.h
+++ b/content/browser/web_contents/web_drag_source_win.h
@@ -29,7 +29,9 @@ class WebDragSource : public ui::DragSourceWin,
                       public NotificationObserver {
  public:
   // Create a new DragSource for a given HWND and WebContents.
-  WebDragSource(gfx::NativeWindow source_wnd, WebContents* web_contents);
+  WebDragSource(gfx::NativeWindow source_wnd,
+                WebContents* web_contents,
+                ui::DragDropTypes::DragEventSource event_source);
   virtual ~WebDragSource();
 
   // NotificationObserver implementation.
@@ -56,6 +58,8 @@ class WebDragSource : public ui::DragSourceWin,
   // OnDragSourceDrop schedules its main work to be done after IDropTarget::Drop
   // by posting a task to this function.
   void DelayedOnDragSourceDrop();
+
+  void CancelLongPressGestureIfNeeded();
 
   // Keep a reference to the window so we can translate the cursor position.
   gfx::NativeWindow source_wnd_;

--- a/ui/base/dragdrop/drag_source_win.cc
+++ b/ui/base/dragdrop/drag_source_win.cc
@@ -6,7 +6,14 @@
 
 namespace ui {
 
-DragSourceWin::DragSourceWin() : cancel_drag_(false) {
+DragSourceWin::DragSourceWin()
+    : cancel_drag_(false),
+      event_source_(DragDropTypes::DRAG_EVENT_SOURCE_MOUSE) {
+}
+
+DragSourceWin::DragSourceWin(DragDropTypes::DragEventSource event_source)
+    : cancel_drag_(false),
+      event_source_(event_source) {
 }
 
 HRESULT DragSourceWin::QueryContinueDrag(BOOL escape_pressed, DWORD key_state) {
@@ -18,7 +25,12 @@ HRESULT DragSourceWin::QueryContinueDrag(BOOL escape_pressed, DWORD key_state) {
     return DRAGDROP_S_CANCEL;
   }
 
-  if (!(key_state & MK_LBUTTON)) {
+  // On Windows, the touch-initiated drag-drop is driven by mouse right down
+  // event programmatically.
+  if ((event_source_ == DragDropTypes::DRAG_EVENT_SOURCE_MOUSE &&
+      !(key_state & MK_LBUTTON)) ||
+      (event_source_ == DragDropTypes::DRAG_EVENT_SOURCE_TOUCH &&
+      !(key_state && MK_RBUTTON))) {
     OnDragSourceDrop();
     return DRAGDROP_S_DROP;
   }

--- a/ui/base/dragdrop/drag_source_win.h
+++ b/ui/base/dragdrop/drag_source_win.h
@@ -9,6 +9,7 @@
 
 #include "base/basictypes.h"
 #include "base/memory/ref_counted.h"
+#include "ui/base/dragdrop/drag_drop_types.h"
 #include "ui/base/ui_export.h"
 
 namespace ui {
@@ -22,6 +23,7 @@ class UI_EXPORT DragSourceWin
       public base::RefCountedThreadSafe<DragSourceWin> {
  public:
   DragSourceWin();
+  explicit DragSourceWin(DragDropTypes::DragEventSource event_source);
   virtual ~DragSourceWin() {}
 
   // Stop the drag operation at the next chance we get.  This doesn't
@@ -48,6 +50,9 @@ class UI_EXPORT DragSourceWin
  private:
   // Set to true if we want to cancel the drag operation.
   bool cancel_drag_;
+
+  // Indicate the drag initiator, mouse or touch.
+  const DragDropTypes::DragEventSource event_source_;
 
   DISALLOW_COPY_AND_ASSIGN(DragSourceWin);
 };


### PR DESCRIPTION
Note this patch is picked from https://codereview.chromium.org/14122008.
So it is safe to remove this commit once the CL is landed.

It already got LGTM from the main reviewer, but since it looks a bit
hacking but still has no better solution as I know, I still need to
spend some time to get LGTM from OWNER.

Use "--enable-touch-drag-drop" to enable it.

TEST=http://html5demos.com/drag
BUG=http://crbug.com/229301

Known issue:
Failed to download file by dragging out.
