### PR TITLE
Making shell use gfx::NativeWindow

### DIFF
--- a/content/shell/shell.h
+++ b/content/shell/shell.h
@@ -233,10 +233,6 @@ class Shell : public WebContentsDelegate,
   WNDPROC default_edit_wnd_proc_;
   static HINSTANCE instance_handle_;
 #elif defined(TOOLKIT_EFL)
-  // TODO(rakuco): Once gfx::NativeWindow is set to Evas_Object*, we
-  // can just use window_.
-  Evas_Object* main_window_;
-
   int content_width_;
   int content_height_;
 #elif defined(TOOLKIT_GTK)

--- a/content/shell/shell_efl.cc
+++ b/content/shell/shell_efl.cc
@@ -52,27 +52,27 @@ void Shell::PlatformCreateWindow(int width, int height) {
   if (headless_)
     return;
 
-  main_window_ = elm_win_util_standard_add("Content Shell", "Content Shell");
+  window_ = elm_win_util_standard_add("Content Shell", "Content Shell");
   //main_window_ = elm_win_add(NULL, "Content Shell", ELM_WIN_BASIC);
 
   //elm_win_title_set(main_window_, "Content Shell");
-  elm_win_autodel_set(main_window_, true);
+  elm_win_autodel_set(window_, true);
 
-  evas_object_resize(main_window_, width, height);
-  evas_object_event_callback_add(main_window_, EVAS_CALLBACK_DEL,
+  evas_object_resize(window_, width, height);
+  evas_object_event_callback_add(window_, EVAS_CALLBACK_DEL,
                                  OnMainWindowDel, this);
 
-  evas_object_show(main_window_);
+  evas_object_show(window_);
 }
 
 void Shell::PlatformSetContents() {
   if (headless_)
     return;
 
-  Evas_Object* view_box = elm_box_add(main_window_);
+  Evas_Object* view_box = elm_box_add(window_);
   evas_object_size_hint_weight_set(view_box, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
 
-  elm_win_resize_object_add(main_window_, view_box);
+  elm_win_resize_object_add(window_, view_box);
  // evas_object_show(view_box);
 
   WebContentsView* content_view = web_contents_->GetView();
@@ -95,7 +95,6 @@ void Shell::Close() {
     delete this;
     return;
   }
-
 }
 
 void Shell::PlatformSetTitle(const string16& title) {
@@ -103,7 +102,7 @@ void Shell::PlatformSetTitle(const string16& title) {
     return;
 
   std::string title_utf8 = UTF16ToUTF8(title);
-  elm_win_title_set(main_window_, title_utf8.c_str());
+  elm_win_title_set(window_, title_utf8.c_str());
 }
 
 void Shell::OnMainWindowDel(void* data, Evas* evas, Evas_Object* object,

--- a/ui/snapshot/snapshot_efl.cc
+++ b/ui/snapshot/snapshot_efl.cc
@@ -10,9 +10,17 @@
 
 namespace ui {
 
-bool GrabViewSnapshot(gfx::NativeView view_handle,
+bool GrabViewSnapshot(gfx::NativeView view,
+                      std::vector<unsigned char>* png_representation,
+                      const gfx::Rect& snapshot_bounds) {
+  // TODO implement EFL snapshot
+  return true;
+}
+
+bool GrabWindowSnapshot(gfx::NativeWindow window,
                         std::vector<unsigned char>* png_representation,
                         const gfx::Rect& snapshot_bounds) {
+  // TODO implement EFL snapshot
   return true;
 }
 


### PR DESCRIPTION
Now that gfx::NativeWindow is set to Evas_Object_, we should just use window_.
and remove Evas_Object_ main_window_
