### PR TITLE
Fix touch support issue on Tizen 2.1

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -374,8 +374,14 @@
       # For example, use_xi2_mt=2 means XI2.2 or above version is required.
       'use_xi2_mt%': 0,
 
-      # Enable multi-touch support based on XInput2.1 in which one touch screen
-      # device for one touch point.
+      # Enable multitouch support with XInput2.1. When it is enabled, unlike
+      # XInput2.2, there are no XI_TouchBegin, XI_TouchUpdate and XI_TouchEnd
+      # raw touch events emitted from touch device. Instead, the touch event is
+      # simulated by a normal mouse event, since X server maintains multiple
+      # virtual touch screen devices as floating device, each of them can
+      # simulate a touch event tracked by the device id of event source, as a
+      # result, multi-touch support works with these simulated touch events
+      # dispatched from floating device.
       'enable_xi21_mt%': 0,
 
       # Use of precompiled headers on Windows.

--- a/ui/base/touch/touch_factory_x11.cc
+++ b/ui/base/touch/touch_factory_x11.cc
@@ -103,9 +103,8 @@ void TouchFactory::UpdateDeviceList(Display* display) {
 #if !defined(ENABLE_XI21_MT)
       if (devtype.string() && !strcmp(devtype.string(), XI_TOUCHSCREEN)) {
 #else
-      // If XInput2.1 based multi-touch is enabled, the device type name is
-      // "MULTITOUCHSCREEN", which is specific to Tizen 2.1 case, not defined
-      // by XInput extension.
+      // Certain Samsung and Intel devices support multi-touch with XInput2.1
+      // using the device type "MULTITOUCHSCREEN".
       if (devtype.string() && !strcmp(devtype.string(), "MULTITOUCHSCREEN")) {
 #endif
         touch_device_lookup_[dev_list[i].id] = true;

--- a/ui/base/x/events_x.cc
+++ b/ui/base/x/events_x.cc
@@ -1007,7 +1007,7 @@ int GetTouchId(const base::NativeEvent& xev) {
   ui::TouchFactory* factory = ui::TouchFactory::GetInstance();
   XIDeviceEvent* xievent = static_cast<XIDeviceEvent*>(xev->xcookie.data);
 #if defined(ENABLE_XI21_MT)
-  // If using XInput2.1 for multi-touch support, the slot is tracked by the
+  // When using XInput2.1 multi-touch support, the slot is tracked by the
   // source id of each device event.
   slot = xievent->sourceid;
 #endif


### PR DESCRIPTION
On Tizen 2.1, the multi-touch support is different from the XInput2.2
approach. It extends the older Input2.1 spec to use multiple touch
devices for multiple touch points, one touch device for one touch
points. The device type name for this purpose is MULTITOUCHSCREEN which
is not defined by XInput extension.

This fix is to make Crosswalk be able to handle the new extension to
XInput2.1 by introducing a new build option 'enable_xi21_mt'. It should
be turned on for Tizen 2.1, and is exclusive to 'use_xi2_mt' option.
