### PR TITLE
Remove invalid resources file entry from chromium resource_ids

### DIFF
--- a/tools/gritsettings/resource_ids
+++ b/tools/gritsettings/resource_ids
@@ -219,10 +219,4 @@
     "includes": [29000],
   },
   # Resource ids starting at 31000 are reserved for projects built on Chromium.
-
-  "cameo/src/runtime/resources/cameo_resources.grd": {
-    "includes": [31000],
-    "structures": [31500],
-    "messages": [32000],
-  },
 }


### PR DESCRIPTION
cameo_resources.grd file has been renamed to xwalk_resources.grd and
added to the xwalk resource_ids already. So, removing an invalid entry
from chromium resource_ids.
