### PR TITLE
[Android] Fix the issue of ContentShell can't play video with file scheme.

### DIFF
--- a/content/renderer/media/android/media_info_loader.cc
+++ b/content/renderer/media/android/media_info_loader.cc
@@ -110,7 +110,7 @@ void MediaInfoLoader::didReceiveResponse(
                "Unknown")
            << " " << response.httpStatusCode();
   DCHECK(active_loader_.get());
-  if (response.httpStatusCode() == kHttpOK) {
+  if (response.httpStatusCode() == kHttpOK || url_.SchemeIsFile()) {
     DidBecomeReady(kOk);
     return;
   }


### PR DESCRIPTION
MediaInfoLoader checks single security origin and CROS access, but for media
resources with file protocol, it always returns false, which disables local
video playback.
