### PR TITLE
Revert bindings generators patch

### DIFF
--- a/build/json_schema_bundle_compile.gypi
+++ b/build/json_schema_bundle_compile.gypi
@@ -30,6 +30,8 @@
         '<@(schema_files)',
       ],
       'outputs': [
+        '<(SHARED_INTERMEDIATE_DIR)/<(cc_dir)/generated_api.h',
+        '<(SHARED_INTERMEDIATE_DIR)/<(cc_dir)/generated_api.cc',
         '<(SHARED_INTERMEDIATE_DIR)/<(cc_dir)/generated_schemas.h',
         '<(SHARED_INTERMEDIATE_DIR)/<(cc_dir)/generated_schemas.cc',
       ],

--- a/tools/json_schema_compiler/cpp_bundle_generator.py
+++ b/tools/json_schema_compiler/cpp_bundle_generator.py
@@ -13,16 +13,7 @@ import os
 import re
 
 # TODO(miket/asargent) - parameterize this.
-SOURCE_BASE_PATH = 'xwalk/jsapi'
-
-# FIXME(tmpsantos): This is a hack for generating the correct
-# includes for the unit tests API. What we should really do is
-# parametrize SOURCE_BASE_PATH.
-def _BasePath(namespace):
-    if namespace.name == "test":
-      return "xwalk/extensions/test"
-    else:
-      return SOURCE_BASE_PATH
+SOURCE_BASE_PATH = 'chrome/common/extensions/api'
 
 def _RemoveDescriptions(node):
   """Returns a copy of |schema| with "description" fields removed.
@@ -251,7 +242,7 @@ class _SchemasCCGenerator(object):
     c = code.Code()
     c.Append(cpp_util.CHROMIUM_LICENSE)
     c.Append()
-    c.Append('#include "%s"' % (os.path.join(_BasePath(namespace),
+    c.Append('#include "%s"' % (os.path.join(SOURCE_BASE_PATH,
                                              'generated_schemas.h')))
     c.Append()
     c.Append('#include "base/lazy_instance.h"')


### PR DESCRIPTION
This patch is no longer needed because we are not using JSON Schema compilers and bundles. Either way, the patch upstream with a proper fix to this got a LGTM and should land soon.
