### PR TITLE
Proactively do BeginFrame when pending tree is activated and no input events are consumed

### DIFF
--- a/cc/output/output_surface.h
+++ b/cc/output/output_surface.h
@@ -100,6 +100,17 @@ class CC_EXPORT OutputSurface : public FrameRateControllerClient {
       bool throttle_frame_production,
       base::TimeDelta interval);
 
+  virtual void SetSafeToProactiveBeginFrame(
+      bool safe_to_proactive_begin_frame) {
+      safe_to_proactive_begin_frame_ = safe_to_proactive_begin_frame;
+  }
+
+  virtual bool SafeToProactiveBeginFrame() {
+    return safe_to_proactive_begin_frame_;
+  }
+
+  virtual void PostProactiveBeginFrame();
+
   void SetMaxFramesPending(int max_frames_pending);
 
   virtual void EnsureBackbuffer();
@@ -173,6 +184,8 @@ class CC_EXPORT OutputSurface : public FrameRateControllerClient {
   virtual void PostCheckForRetroactiveBeginFrame();
   void CheckForRetroactiveBeginFrame();
 
+  void ProactiveBeginFrame();
+
  private:
   OutputSurfaceClient* client_;
   friend class OutputSurfaceCallbacks;
@@ -186,6 +199,8 @@ class CC_EXPORT OutputSurface : public FrameRateControllerClient {
   // check_for_retroactive_begin_frame_pending_ is used to avoid posting
   // redundant checks for a retroactive BeginFrame.
   bool check_for_retroactive_begin_frame_pending_;
+  bool safe_to_proactive_begin_frame_;
+  bool proactive_begin_frame_pending_;
 
   DISALLOW_COPY_AND_ASSIGN(OutputSurface);
 };

--- a/cc/trees/layer_tree_host_impl.h
+++ b/cc/trees/layer_tree_host_impl.h
@@ -358,6 +358,7 @@ class CC_EXPORT LayerTreeHostImpl
   }
 
   bool pinch_gesture_active() const { return pinch_gesture_active_; }
+  bool animate_layers_active() const { return animate_layers_active_; }
 
   void SetTreePriority(TreePriority priority);
 
@@ -479,6 +480,7 @@ class CC_EXPORT LayerTreeHostImpl
   // This is set by AnimateLayers() and used by UpdateAnimationState()
   // when sending animation events to the main thread.
   base::Time last_animation_time_;
+  bool animate_layers_active_;
 
   scoped_ptr<TopControlsManager> top_controls_manager_;
 

--- a/cc/trees/thread_proxy.h
+++ b/cc/trees/thread_proxy.h
@@ -179,6 +179,7 @@ class ThreadProxy : public Proxy,
   void DidSwapUseIncompleteTileOnImplThread();
   void StartScrollbarAnimationOnImplThread();
   void MainThreadHasStoppedFlingingOnImplThread();
+  void ProactiveBeginFrameOnImplThread();
 
   // Accessed on main thread only.
 


### PR DESCRIPTION
This is a continuing work on https://github.com/crosswalk-project/chromium-crosswalk/pull/52 after the code base has been updated to align with Chromium 29.

Since the architecture is changed in the upgrade to Chromium 29, a different approach is used in this  patch and it can get the similar performance improvement with the one at https://github.com/crosswalk-project/chromium-crosswalk/pull/52. 

Chromium upstream(Google guys) has merged this logic into their deadline-scheduling approach and can get similar performance gain. The related patch has been landed into chromium 31.0.1639.1. It is now enabled by default for android, and for other platforms you need to enable it from about://flags or add command line flags "--enable-deadline-scheduling". The details can be found at http://code.google.com/p/chromium/issues/detail?id=284247 and http://code.google.com/p/chromium/issues/detail?id=243461.

It is better to merge this logic alone to Crosswalk to get the performance gain at present, a future rebase to M31 can get the whole updates on Chrome Compositor.
