### PR TITLE
[Tizen] Don't SetProcessTitleFromCommandLine.

### DIFF
--- a/content/app/content_main_runner.cc
+++ b/content/app/content_main_runner.cc
@@ -728,7 +728,7 @@ class ContentMainRunnerImpl : public ContentMainRunner {
     if (delegate)
       delegate->SandboxInitialized(process_type);
 
-#if defined(OS_POSIX) && !defined(OS_IOS)
+#if defined(OS_POSIX) && !defined(OS_IOS) && !defined(OS_TIZEN_MOBILE)
     SetProcessTitleFromCommandLine(argv);
 #endif
 


### PR DESCRIPTION
SetProcessTitleFromCommandLine changes process title to absolute path of the
executable.

It has two issues on Tizen.
1. Tizen task manager can not recognize xwalk process.
2. Web app uses symbol link to the xwalk executable. Web app process title must
show symbol link path, not xwalk executable path for the task manager to
recognize Web app, not XWalk.
