### PR TITLE
Backport upstream r210813 to fix Aura color chooser crash on Debug build

### DIFF
--- a/ui/views/color_chooser/color_chooser_view.cc
+++ b/ui/views/color_chooser/color_chooser_view.cc
@@ -256,7 +256,6 @@ void ColorChooserView::SaturationValueView::OnSaturationValueChanged(
   marker_position_.set_x(x);
   marker_position_.set_y(y);
   SchedulePaint();
-  chooser_view_->OnSaturationValueChosen(saturation, value);
 }
 
 void ColorChooserView::SaturationValueView::ProcessEventAtLocation(
@@ -269,6 +268,7 @@ void ColorChooserView::SaturationValueView::ProcessEventAtLocation(
   saturation = SkScalarPin(saturation, 0, SK_Scalar1);
   value = SkScalarPin(value, 0, SK_Scalar1);
   OnSaturationValueChanged(saturation, value);
+  chooser_view_->OnSaturationValueChosen(saturation, value);
 }
 
 gfx::Size ColorChooserView::SaturationValueView::GetPreferredSize() {


### PR DESCRIPTION
Origin commit log:
    Do not send OnColorChosen when initialized.

```
keishi pointed out that ColorChooserView somehow sends OnColorChosen
in its constructor which may cause a failure on DCHECK() in renderer.

The constructor calls OnColorChanged() which calls
OnSaturationValueChanged() which actually calls OnColorChosen().
Actually this is a mistake, OnColorChosen() should be called only when
the user takes some action (like mouse click) and HueView works like that.

BUG=258221
R=sky@chromium.org

Review URL: https://chromiumcodereview.appspot.com/18945002

git-svn-id: svn://svn.chromium.org/chrome/trunk/src@210813 0039d316-1c4b-4281-b951-d872f2087c98
```
