### PR TITLE
[Tizen] Change Sandbox IPC process title.

### DIFF
--- a/content/app/content_main_runner.cc
+++ b/content/app/content_main_runner.cc
@@ -728,7 +728,12 @@ class ContentMainRunnerImpl : public ContentMainRunner {
     if (delegate)
       delegate->SandboxInitialized(process_type);
 
-#if defined(OS_POSIX) && !defined(OS_IOS) && !defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN_MOBILE)
+    if (process_type.empty())
+      StoreArgvPointerAddress(argv);
+    else
+      SetProcessTitleFromCommandLine(argv);
+#elif defined(OS_POSIX) && !defined(OS_IOS)
     SetProcessTitleFromCommandLine(argv);
 #endif
 

--- a/content/browser/renderer_host/render_sandbox_host_linux.cc
+++ b/content/browser/renderer_host/render_sandbox_host_linux.cc
@@ -37,6 +37,10 @@
 #include "third_party/skia/include/ports/SkFontConfigInterface.h"
 #include "ui/gfx/font_render_params_linux.h"
 
+#if defined(OS_TIZEN_MOBILE)
+#include "content/common/set_process_title.h"
+#endif
+
 using WebKit::WebCString;
 using WebKit::WebFontInfo;
 using WebKit::WebUChar;
@@ -70,6 +74,10 @@ class SandboxIPCProcess  {
     // positioning, so we pass the current setting through to WebKit.
     WebFontInfo::setSubpixelPositioning(
         gfx::GetDefaultWebkitSubpixelPositioning());
+
+#if defined(OS_TIZEN_MOBILE)
+    SetProcessTitleFromCommandLine(NULL);
+#endif
   }
 
   ~SandboxIPCProcess();

--- a/content/common/set_process_title.cc
+++ b/content/common/set_process_title.cc
@@ -87,4 +87,10 @@ void SetProcessTitleFromCommandLine(const char** /* main_argv */) {
 
 #endif
 
+#if defined(OS_TIZEN_MOBILE)
+void StoreArgvPointerAddress(const char** main_argv) {
+  setproctitle_init(main_argv);
+}
+#endif
+
 } // namespace content

--- a/content/common/set_process_title.h
+++ b/content/common/set_process_title.h
@@ -22,6 +22,10 @@ namespace content {
 // will try to fix it so the "effective" command line shows up instead.
 void SetProcessTitleFromCommandLine(const char** main_argv);
 
+#if defined(OS_TIZEN_MOBILE)
+void StoreArgvPointerAddress(const char** main_argv);
+#endif
+
 }  // namespace content
 
 #endif  // CONTENT_COMMON_SET_PROCESS_TITLE_H_


### PR DESCRIPTION
SetProcessTitleFromCommandLine() plays a role to change process title to
absolute path of the executable with arguments that the CommandLine object has.
For example, we want gpu process title to be "<xwalk dir>/xwalk
--type=gpu-process", not "/proc/self/exe --type=gpu-process"

However, we don't want to change browser process title, because browser process
title should be web app symbolic link path, not xwalk executable absolute path.

SandboxIPC process is the process forked by browser process. We want that
SandboxIPC process title is different from browser process title. Otherwise,
Tizen task switcher misunderstands that SandboxIPC process is also web
application process.

To achieve it,
1. Browser process must not call SetProcessTitleFromCommandLine();
2. Browser process must save argv pointer to change SandboxIPC process title later.
3. SandboxIPC process also calls SetProcessTitleFromCommandLine() to change its own process title.

BUG=https://github.com/crosswalk-project/crosswalk/issues/609
