### PR TITLE
[Tizen] DesktopRootWindowHost factory is not needed.

### DIFF
--- a/ui/views/widget/desktop_aura/desktop_root_window_host.h
+++ b/ui/views/widget/desktop_aura/desktop_root_window_host.h
@@ -38,16 +38,6 @@ class VIEWS_EXPORT DesktopRootWindowHost {
       DesktopNativeWidgetAura* desktop_native_widget_aura,
       const gfx::Rect& initial_bounds);
 
-  typedef DesktopRootWindowHost* (DesktopRootWindowHostFactory)(
-      internal::NativeWidgetDelegate* native_widget_delegate,
-      DesktopNativeWidgetAura* desktop_native_widget_aura,
-      const gfx::Rect& initial_bounds);
-  // Uses the given DesktopRootWindowHostFactory to override the default
-  // DesktopRootWindowHost implementation for embedder.
-  // Returns true if the factory was successfully registered.
-  static bool InitDesktopRootWindowHostFactory(
-      DesktopRootWindowHostFactory* factory);
-
   // Return the NativeTheme to use for |window|.
   static ui::NativeTheme* GetNativeTheme(aura::Window* window);
 

--- a/ui/views/widget/desktop_aura/desktop_root_window_host_win.cc
+++ b/ui/views/widget/desktop_aura/desktop_root_window_host_win.cc
@@ -875,10 +875,4 @@ DesktopRootWindowHost* DesktopRootWindowHost::Create(
                                       initial_bounds);
 }
 
-// static
-bool DesktopRootWindowHost::InitDesktopRootWindowHostFactory(
-    DesktopRootWindowHostFactory* factory) {
-  return true;
-}
-
 }  // namespace views

--- a/ui/views/widget/desktop_aura/desktop_root_window_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_root_window_host_x11.cc
@@ -55,9 +55,6 @@ DEFINE_WINDOW_PROPERTY_KEY(
 
 namespace {
 
-DesktopRootWindowHost::DesktopRootWindowHostFactory*
-    desktop_root_window_host_factory_ = NULL;
-
 // Standard Linux mouse buttons for going back and forward.
 const int kBackMouseButton = 8;
 const int kForwardMouseButton = 9;
@@ -1201,23 +1198,9 @@ DesktopRootWindowHost* DesktopRootWindowHost::Create(
     internal::NativeWidgetDelegate* native_widget_delegate,
     DesktopNativeWidgetAura* desktop_native_widget_aura,
     const gfx::Rect& initial_bounds) {
-  if (desktop_root_window_host_factory_)
-    return desktop_root_window_host_factory_(native_widget_delegate,
-                                             desktop_native_widget_aura,
-                                             initial_bounds);
   return new DesktopRootWindowHostX11(native_widget_delegate,
                                         desktop_native_widget_aura,
                                         initial_bounds);
-}
-
-// static
-bool DesktopRootWindowHost::InitDesktopRootWindowHostFactory(
-    DesktopRootWindowHostFactory* factory) {
-  if (desktop_root_window_host_factory_)
-    return false;
-
-  desktop_root_window_host_factory_ = factory;
-  return true;
 }
 
 }  // namespace views


### PR DESCRIPTION
[Tizen] DesktopRootWindowHost factory is not needed.

After Crosswalk revision(08e61f325): Provide our DesktopRootWindowHost using OnBeforeWidgetInit()
DesktopRootWindowHost factory is not needed.
DesktopRootWindowHost factory was made by Intel, and we want to revert it to
minimize chromium changes.

Revert "Add factory mechanism to DesktopRootWindowHost."

This reverts commit 20ac69924e1b16d1e7ff918dce3cc22bd4142d04.
