### PR TITLE
[Android] Support shared library mode for XWalkRuntime in WindowAndroid. 

### DIFF
--- a/ui/android/java/src/org/chromium/ui/WindowAndroid.java
+++ b/ui/android/java/src/org/chromium/ui/WindowAndroid.java
@@ -34,6 +34,7 @@ public class WindowAndroid {
 
     private int mNextRequestCode = 0;
     protected Activity mActivity;
+    protected Context mContext;
     protected SparseArray<IntentCallback> mOutstandingIntents;
     protected HashMap<Integer, String> mIntentErrors;
 
@@ -41,7 +42,16 @@ public class WindowAndroid {
      * @param activity
      */
     public WindowAndroid(Activity activity) {
+        this(activity, activity);
+    }
+
+    /**
+     * @param activity
+     * @param context
+     */
+    public WindowAndroid(Activity activity, Context context) {
         mActivity = activity;
+        mContext = context;
         mOutstandingIntents = new SparseArray<IntentCallback>();
         mIntentErrors = new HashMap<Integer, String>();
 
@@ -100,7 +110,7 @@ public class WindowAndroid {
      * @return Activity context.
      */
     public Context getContext() {
-        return mActivity;
+        return mContext;
     }
 
     /**


### PR DESCRIPTION
XWalkRuntime in shared mode requires WindowAndroid to have a share library context
to get resources in shared library. Add constructor in WindowAndroid to make it work.

BUG=https://github.com/crosswalk-project/crosswalk/issues/678 , 666
