### PR TITLE
Revert "[Android] Support shared library mode for XWalkRuntime in Window...

### DIFF
--- a/ui/android/java/src/org/chromium/ui/WindowAndroid.java
+++ b/ui/android/java/src/org/chromium/ui/WindowAndroid.java
@@ -34,7 +34,6 @@ public class WindowAndroid {
 
     private int mNextRequestCode = 0;
     protected Activity mActivity;
-    protected Context mContext;
     protected SparseArray<IntentCallback> mOutstandingIntents;
     protected HashMap<Integer, String> mIntentErrors;
 
@@ -42,16 +41,7 @@ public class WindowAndroid {
      * @param activity
      */
     public WindowAndroid(Activity activity) {
-        this(activity, activity);
-    }
-
-    /**
-     * @param activity
-     * @param context
-     */
-    public WindowAndroid(Activity activity, Context context) {
         mActivity = activity;
-        mContext = context;
         mOutstandingIntents = new SparseArray<IntentCallback>();
         mIntentErrors = new HashMap<Integer, String>();
 
@@ -110,7 +100,7 @@ public class WindowAndroid {
      * @return Activity context.
      */
     public Context getContext() {
-        return mContext;
+        return mActivity;
     }
 
     /**


### PR DESCRIPTION
...Android."

This reverts commit d63fbcbe8846417ff67331a07d467e56a833d803.

Because https://github.com/crosswalk-project/crosswalk/pull/803 fixes the
issue in crosswalk side. Revert the fix in chromium to decrease rebase effort.

TODO:Remove both commits when doing next rebase.
