### PR TITLE
[Android] Fix the render issue introduced by single process mode.

### DIFF
--- a/content/browser/renderer_host/compositor_impl_android.cc
+++ b/content/browser/renderer_host/compositor_impl_android.cc
@@ -398,7 +398,8 @@ CreateGpuProcessViewContext(
       new WebGraphicsContext3DCommandBufferImpl(surface_id,
                                                 url,
                                                 factory,
-                                                compositor_impl));
+                                                compositor_impl,
+                                                true));
   static const size_t kBytesPerPixel = 4;
   gfx::DeviceDisplayInfo display_info;
   size_t full_screen_texture_size_in_bytes =

--- a/content/browser/renderer_host/image_transport_factory_android.cc
+++ b/content/browser/renderer_host/image_transport_factory_android.cc
@@ -112,7 +112,8 @@ CmdBufferImageTransportFactory::CmdBufferImageTransportFactory() {
   context_.reset(new WebGraphicsContext3DCommandBufferImpl(0, // offscreen
                                                            url,
                                                            factory,
-                                                           swap_client));
+                                                           swap_client,
+                                                           true));
   static const size_t kBytesPerPixel = 4;
   gfx::DeviceDisplayInfo display_info;
   size_t full_screen_texture_size_in_bytes =

--- a/content/common/gpu/client/webgraphicscontext3d_command_buffer_impl.h
+++ b/content/common/gpu/client/webgraphicscontext3d_command_buffer_impl.h
@@ -83,7 +83,8 @@ class WebGraphicsContext3DCommandBufferImpl
       int surface_id,
       const GURL& active_url,
       GpuChannelHostFactory* factory,
-      const base::WeakPtr<WebGraphicsContext3DSwapBuffersClient>& swap_client);
+      const base::WeakPtr<WebGraphicsContext3DSwapBuffersClient>& swap_client,
+      bool context_for_browser_compositor = false);
 
   virtual ~WebGraphicsContext3DCommandBufferImpl();
 
@@ -765,6 +766,8 @@ class WebGraphicsContext3DCommandBufferImpl
   size_t min_transfer_buffer_size_;
   size_t max_transfer_buffer_size_;
   size_t mapped_memory_limit_;
+
+  bool context_for_browser_compositor_;
 
   uint32_t flush_id_;
 };


### PR DESCRIPTION
- In Chromium, single process mode is only for Android WebView, ContentShell and
  its derivatives only go to the multiple process mode.
- The context design is only for multiple process mode(ContentShell/XWalk), if we
  force running it with single process mode, there are issues (black regions for
  video/canvas/webgl layers, and black screen for stop/restart actions). The reason
  is that Android port has browser-side compositor, and the shared context in
  browser-side compositor has conflicts with renderer's contexts if running in single
  process mode.
- To run ContentShell/XWalk in single process mode, we have to resolve the shared
  context issue between renderer/browser.

BUG=https://github.com/crosswalk-project/crosswalk/issues/516
