### PR TITLE
[Tizen] Camera driver integration for Tizen

### DIFF
--- a/media/media.gyp
+++ b/media/media.gyp
@@ -574,6 +574,19 @@
             ],
           },
           'conditions': [
+            ['tizen_mobile==1', {
+             'cflags': [
+                '<!@(<(pkg-config) --cflags gstreamer-0.10 gstreamer-atomisphal-0.10)',
+                # __user macro is used in mfld driver header atomisp.h, and it needs to be
+                # defined for Tizen environment, otherwise there are compiler errors.
+                '-D__user=',
+              ],
+              'link_settings': {
+                'libraries': [
+                  '<!@(<(pkg-config) --libs gstreamer-0.10 gstreamer-atomisphal-0.10)',
+                ],
+              },
+            }],
             ['use_x11==1', {
               'link_settings': {
                 'libraries': [


### PR DESCRIPTION
On Tizen 2.1, apps/libs that want to use camera are supposed to talk to the
gst-plugin 'camerasrc'. This element in turn interacts with the camera device
via the platform-specific interfaces in addition to the standard linux 'v4l2'
interfaces. However chromium currently can only work with the 'v4l2' camera
devices. So it's unable to drive camera on Tizen. The solution is to make
chromium aware of those platform-specific interfaces.

As a result of hacking 'camerasrc', this patch minimally cherry-picked the code
snippets from it that can barely bring up the camera, and dropped other plenty
of gstreamer-related code in order to maximally keep chromium clean meanwhile.
