### PR TITLE
[Temp] Add test interface for device motion/orientation.

### DIFF
--- a/content/browser/device_orientation/device_inertial_sensor_service.cc
+++ b/content/browser/device_orientation/device_inertial_sensor_service.cc
@@ -91,4 +91,9 @@ void DeviceInertialSensorService::Shutdown() {
   is_shutdown_ = true;
 }
 
+void DeviceInertialSensorService::SetDataFetcherForTests(
+    DataFetcherSharedMemory* test_data_fetcher) {
+  data_fetcher_.reset(test_data_fetcher);
+}
+
 }  // namespace content

--- a/content/browser/device_orientation/device_inertial_sensor_service.h
+++ b/content/browser/device_orientation/device_inertial_sensor_service.h
@@ -44,6 +44,10 @@ class CONTENT_EXPORT DeviceInertialSensorService {
   // Stop/join with the background polling thread in |provider_|.
   void Shutdown();
 
+  // Injects a custom data fetcher for testing purposes. This class takes
+  // ownership of the injected object.
+  void SetDataFetcherForTests(DataFetcherSharedMemory* test_data_fetcher);
+
  private:
   friend struct DefaultSingletonTraits<DeviceInertialSensorService>;
 


### PR DESCRIPTION
This change is cherry-picked from upstream revision 225702
(https://src.chromium.org/viewvc/chrome?view=rev&revision=225702).
Crosswalk need this interface to implement device orientation
API (http://www.w3.org/TR/orientation-event/).

BUG=https://code.google.com/p/chromium/issues/detail?id=261165
