### PR TITLE
[Tizen] Use DesktopRootWindowHostX11 in chromium, instead of DesktopRootWindowHostTizenX11.

### DIFF
--- a/ui/views/widget/desktop_aura/desktop_root_window_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_root_window_host_x11.cc
@@ -1129,17 +1129,13 @@ bool DesktopRootWindowHostX11::Dispatch(const base::NativeEvent& event) {
       int num_coalesced = 0;
 
       switch (type) {
-        // case ui::ET_TOUCH_MOVED:
-        //   num_coalesced = CoalescePendingMotionEvents(xev, &last_event);
-        //   if (num_coalesced > 0)
-        //     xev = &last_event;
-        //   // fallthrough
-        // case ui::ET_TOUCH_PRESSED:
-        // case ui::ET_TOUCH_RELEASED: {
-        //   ui::TouchEvent touchev(xev);
-        //   root_window_host_delegate_->OnHostTouchEvent(&touchev);
-        //   break;
-        // }
+        case ui::ET_TOUCH_MOVED:
+        case ui::ET_TOUCH_PRESSED:
+        case ui::ET_TOUCH_RELEASED: {
+          ui::TouchEvent touchev(xev);
+          root_window_host_delegate_->OnHostTouchEvent(&touchev);
+          break;
+        }
         case ui::ET_MOUSE_MOVED:
         case ui::ET_MOUSE_DRAGGED:
         case ui::ET_MOUSE_PRESSED:


### PR DESCRIPTION
[Tizen] Use DesktopRootWindowHostX11 in chromium, instead of DesktopRootWindowHostTizenX11.

Rationale
1. Bugs are created when we rebase to upstream because of confliction.
2. Hard to follow up upstream changes.
3. We need to change DesktopRootWindowHostX11 pretty smaller than we expected.

BUG=https://crosswalk-project.org/jira/browse/XWALK-12
