### PR TITLE
[Tizen] Change scrollbar animator

### DIFF
--- a/content/renderer/gpu/render_widget_compositor.cc
+++ b/content/renderer/gpu/render_widget_compositor.cc
@@ -291,7 +291,11 @@ scoped_ptr<RenderWidgetCompositor> RenderWidgetCompositor::Create(
       !cmd->HasSwitch(cc::switches::kDisable4444Textures);
 #elif !defined(OS_MACOSX)
   if (cmd->HasSwitch(switches::kEnableOverlayScrollbars)) {
+#if defined(OS_TIZEN_MOBILE)
+    settings.scrollbar_animator = cc::LayerTreeSettings::LinearFade;
+#else
     settings.scrollbar_animator = cc::LayerTreeSettings::Thinning;
+#endif
     settings.solid_color_scrollbars = true;
   }
   if (cmd->HasSwitch(cc::switches::kEnablePinchVirtualViewport) ||


### PR DESCRIPTION
Based on patch from: Kenneth Rohde Christiansen kenneth.r.christiansen@intel.com

Since we have enabled overlay scrollbars we now get the desktop behavior, which means that a thin scroll indicator is always visible, which immediately grows when scrolling and shrinks (animated) back to the small size when scrolling is over.

On Tizen we want a different behavior:
a) no scroll indicator when not scrolling
b) a think scroll indicator which is slightly offset from the right viewport edge
c) the scroll indicator should fade out (animated) when the scroll is over

This patch is changing the scrollbar animator to 'fade out' and fixes 'a)' and 'c)' from the list above.
