### PR TITLE
Introduce OS_TIZEN and set specific settings for Tizen platforms

### DIFF
--- a/content/renderer/gpu/render_widget_compositor.cc
+++ b/content/renderer/gpu/render_widget_compositor.cc
@@ -291,7 +291,8 @@ scoped_ptr<RenderWidgetCompositor> RenderWidgetCompositor::Create(
       !cmd->HasSwitch(cc::switches::kDisable4444Textures);
 #elif !defined(OS_MACOSX)
   if (cmd->HasSwitch(switches::kEnableOverlayScrollbars)) {
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
+    // Tizen fades out the scrollbar after contents interaction ends.
     settings.scrollbar_animator = cc::LayerTreeSettings::LinearFade;
 #else
     settings.scrollbar_animator = cc::LayerTreeSettings::Thinning;

--- a/content/renderer/web_preferences.cc
+++ b/content/renderer/web_preferences.cc
@@ -322,6 +322,20 @@ void ApplyWebPreferences(const WebPreferences& prefs, WebView* web_view) {
 
   settings->setSelectionIncludesAltImageText(true);
 
+#if defined(OS_TIZEN)
+  // Scrollbars should not be stylable.
+  settings->setAllowCustomScrollbarInMainFrame(false);
+
+  // Don't auto play music on Tizen devices.
+  settings->setMediaPlaybackRequiresUserGesture(true);
+
+  // IME support
+  settings->setAutoZoomFocusedNodeToLegibleScale(true);
+
+  // Enable double tap to zoom when zoomable.
+  settings->setDoubleTapToZoomEnabled(true);
+#endif
+
 #if defined(OS_ANDROID)
   settings->setAllowCustomScrollbarInMainFrame(false);
   settings->setTextAutosizingEnabled(prefs.text_autosizing_enabled);


### PR DESCRIPTION
This includes disabling site themed scrollbars (we use overlay
scrollbars always), enabling double tap to zoom for zoomable pages,
disable auto playing of music (a touch is needed) as well as
moving input fields into the view when focused.

It also enables the fade out scrollbars on all Tizen platforms, not
just mobile.
