### PR TITLE
Revert "x11: Fix a few touch-event related issues:"

### DIFF
--- a/ui/events/event_switches.cc
+++ b/ui/events/event_switches.cc
@@ -20,7 +20,7 @@ const char kTouchEventsEnabled[] = "enabled";
 //   disabled: touch events are disabled.
 const char kTouchEventsDisabled[] = "disabled";
 
-#if defined(OS_LINUX)
+#if defined(TOOLKIT_VIEWS) && defined(OS_LINUX)
 // Tells chrome to interpret events from these devices as touch events. Only
 // available with XInput 2 (i.e. X server 1.8 or above). The id's of the
 // devices can be retrieved from 'xinput list'.

--- a/ui/events/event_switches.h
+++ b/ui/events/event_switches.h
@@ -16,7 +16,7 @@ EVENTS_EXPORT extern const char kTouchEventsAuto[];
 EVENTS_EXPORT extern const char kTouchEventsEnabled[];
 EVENTS_EXPORT extern const char kTouchEventsDisabled[];
 
-#if defined(OS_LINUX)
+#if defined(TOOLKIT_VIEWS) && defined(OS_LINUX)
 EVENTS_EXPORT extern const char kTouchDevices[];
 #endif
 

--- a/ui/events/x/device_data_manager.cc
+++ b/ui/events/x/device_data_manager.cc
@@ -59,6 +59,7 @@
 #define AXIS_LABEL_ABS_MT_TOUCH_MINOR "Abs MT Touch Minor"
 #define AXIS_LABEL_ABS_MT_ORIENTATION "Abs MT Orientation"
 #define AXIS_LABEL_ABS_MT_PRESSURE    "Abs MT Pressure"
+#define AXIS_LABEL_ABS_MT_SLOT_ID     "Abs MT Slot ID"
 #define AXIS_LABEL_ABS_MT_TRACKING_ID "Abs MT Tracking ID"
 #define AXIS_LABEL_TOUCH_TIMESTAMP    "Touch Timestamp"
 
@@ -83,6 +84,9 @@ const char* kCachedAtoms[] = {
   AXIS_LABEL_ABS_MT_TOUCH_MINOR,
   AXIS_LABEL_ABS_MT_ORIENTATION,
   AXIS_LABEL_ABS_MT_PRESSURE,
+#if !defined(USE_XI2_MT)
+  AXIS_LABEL_ABS_MT_SLOT_ID,
+#endif
   AXIS_LABEL_ABS_MT_TRACKING_ID,
   AXIS_LABEL_TOUCH_TIMESTAMP,
 
@@ -304,18 +308,13 @@ bool DeviceDataManager::GetEventData(const XEvent& xev,
   if (valuator_lookup_[sourceid].empty())
     return false;
 
+#if defined(USE_XI2_MT)
+  // With XInput2 MT, Tracking ID is provided in the detail field.
   if (type == DT_TOUCH_TRACKING_ID) {
-    // With XInput2 MT, Tracking ID is provided in the detail field for touch
-    // events.
-    if (xiev->evtype == XI_TouchBegin ||
-        xiev->evtype == XI_TouchEnd ||
-        xiev->evtype == XI_TouchUpdate) {
-      *value = xiev->detail;
-    } else {
-      *value = 0;
-    }
+    *value = xiev->detail;
     return true;
   }
+#endif
 
   int val_index = valuator_lookup_[sourceid][type];
   int slot = 0;

--- a/ui/events/x/device_data_manager.h
+++ b/ui/events/x/device_data_manager.h
@@ -73,6 +73,22 @@ class EVENTS_EXPORT DeviceDataManager {
                           // touch area.
     DT_TOUCH_PRESSURE,    // Pressure of the touch contact.
 
+    // NOTE: A touch event can have multiple touch points. So when we receive a
+    // touch event, we need to determine which point triggered the event.
+    // A touch point can have both a 'Slot ID' and a 'Tracking ID', and they can
+    // be (in fact, usually are) different. The 'Slot ID' ranges between 0 and
+    // (X - 1), where X is the maximum touch points supported by the device. The
+    // 'Tracking ID' can be any 16-bit value. With XInput 2.0, an XI_Motion
+    // event that comes from a currently-unused 'Slot ID' indicates the creation
+    // of a new touch point, and any event that comes with a 0 value for
+    // 'Tracking ID' marks the removal of a touch point. During the lifetime of
+    // a touchpoint, we use the 'Slot ID' as its identifier. The XI_ButtonPress
+    // and XI_ButtonRelease events are ignored.
+#if !defined(USE_XI2_MT)
+    DT_TOUCH_SLOT_ID,     // ID of the finger that triggered a touch event
+                          // (useful when tracking multiple simultaneous
+                          // touches).
+#endif
     // NOTE for XInput MT: 'Tracking ID' is provided in every touch event to
     // track individual touch. 'Tracking ID' is an unsigned 32-bit value and
     // is increased for each new touch. It will wrap back to 0 when reaching

--- a/ui/events/x/events_x.cc
+++ b/ui/events/x/events_x.cc
@@ -195,22 +195,60 @@ ui::EventType GetTouchEventType(const base::NativeEvent& native_event) {
       return TouchEventIsGeneratedHack(native_event) ? ui::ET_TOUCH_CANCELLED :
                                                        ui::ET_TOUCH_RELEASED;
   }
-#endif  // defined(USE_XI2_MT)
 
-  DCHECK(ui::TouchFactory::GetInstance()->IsTouchDevice(event->sourceid));
-  switch (event->evtype) {
-    case XI_ButtonPress:
-      return ui::ET_TOUCH_PRESSED;
-    case XI_ButtonRelease:
-      return ui::ET_TOUCH_RELEASED;
-    case XI_Motion:
-      if (GetButtonMaskForX2Event(event))
-        return ui::ET_TOUCH_MOVED;
-      return ui::ET_UNKNOWN;
-    default:
-      NOTREACHED();
-  }
   return ui::ET_UNKNOWN;
+#else
+  ui::TouchFactory* factory = ui::TouchFactory::GetInstance();
+
+  // If this device doesn't support multi-touch, then just use the normal
+  // pressed/release events to indicate touch start/end.  With multi-touch,
+  // these events are sent only for the first (pressed) or last (released)
+  // touch point, and so we must infer start/end from motion events.
+  if (!factory->IsMultiTouchDevice(event->sourceid)) {
+    switch (event->evtype) {
+      case XI_ButtonPress:
+        return ui::ET_TOUCH_PRESSED;
+      case XI_ButtonRelease:
+        return ui::ET_TOUCH_RELEASED;
+      case XI_Motion:
+        if (GetButtonMaskForX2Event(event))
+          return ui::ET_TOUCH_MOVED;
+        return ui::ET_UNKNOWN;
+      default:
+        NOTREACHED();
+    }
+  }
+
+  DCHECK_EQ(event->evtype, XI_Motion);
+
+  // Note: We will not generate a _STATIONARY event here. It will be created,
+  // when necessary, by a RWHVV.
+  // TODO(sad): When should _CANCELLED be generated?
+
+  ui::DeviceDataManager* manager = ui::DeviceDataManager::GetInstance();
+
+  double slot;
+  if (!manager->GetEventData(
+      *native_event, ui::DeviceDataManager::DT_TOUCH_SLOT_ID, &slot))
+    return ui::ET_UNKNOWN;
+
+  if (!factory->IsSlotUsed(slot)) {
+    // This is a new touch point.
+    return ui::ET_TOUCH_PRESSED;
+  }
+
+  double tracking;
+  if (!manager->GetEventData(
+      *native_event, ui::DeviceDataManager::DT_TOUCH_TRACKING_ID, &tracking))
+    return ui::ET_UNKNOWN;
+
+  if (tracking == 0l) {
+    // The touch point has been released.
+    return ui::ET_TOUCH_RELEASED;
+  }
+
+  return ui::ET_TOUCH_MOVED;
+#endif  // defined(USE_XI2_MT)
 }
 
 double GetTouchParamFromXEvent(XEvent* xev,
@@ -533,6 +571,7 @@ gfx::Vector2d GetMouseWheelOffset(const base::NativeEvent& native_event) {
 }
 
 void ClearTouchIdIfReleased(const base::NativeEvent& xev) {
+#if defined(USE_XI2_MT)
   ui::EventType type = ui::EventTypeFromNative(xev);
   if (type == ui::ET_TOUCH_CANCELLED ||
       type == ui::ET_TOUCH_RELEASED) {
@@ -544,25 +583,39 @@ void ClearTouchIdIfReleased(const base::NativeEvent& xev) {
       factory->ReleaseSlotForTrackingID(tracking_id);
     }
   }
+#endif
 }
 
 int GetTouchId(const base::NativeEvent& xev) {
   double slot = 0;
+  ui::TouchFactory* factory = ui::TouchFactory::GetInstance();
+  XIDeviceEvent* xievent = static_cast<XIDeviceEvent*>(xev->xcookie.data);
 #if defined(ENABLE_XI21_MT)
   // If using XInput2.1 for multi-touch support, the slot is tracked by the
   // source id of each device event.
-  XIDeviceEvent* xievent = static_cast<XIDeviceEvent*>(xev->xcookie.data);
   slot = xievent->sourceid;
 #endif
+  if (!factory->IsMultiTouchDevice(xievent->sourceid)) {
+    // TODO(sad): Come up with a way to generate touch-ids for multi-touch
+    // events when touch-events are generated from a single-touch device.
+    return slot;
+  }
+
   ui::DeviceDataManager* manager = ui::DeviceDataManager::GetInstance();
+
+#if defined(USE_XI2_MT)
   double tracking_id;
   if (!manager->GetEventData(
       *xev, ui::DeviceDataManager::DT_TOUCH_TRACKING_ID, &tracking_id)) {
     LOG(ERROR) << "Could not get the tracking ID for the event. Using 0.";
   } else {
-    ui::TouchFactory* factory = ui::TouchFactory::GetInstance();
     slot = factory->GetSlotForTrackingID(tracking_id);
   }
+#else
+  if (!manager->GetEventData(
+      *xev, ui::DeviceDataManager::DT_TOUCH_SLOT_ID, &slot))
+    LOG(ERROR) << "Could not get the slot ID for the event. Using 0.";
+#endif
   return slot;
 }
 

--- a/ui/events/x/touch_factory_x11.cc
+++ b/ui/events/x/touch_factory_x11.cc
@@ -29,7 +29,10 @@ TouchFactory::TouchFactory()
       touch_device_available_(false),
       touch_events_disabled_(false),
       touch_device_list_(),
-      id_generator_(0) {
+#if defined(USE_XI2_MT)
+      id_generator_(0),
+#endif
+      slots_used_() {
 #if defined(USE_AURA)
   if (!base::MessagePumpForUI::HasXInput2())
     return;
@@ -54,6 +57,7 @@ TouchFactory* TouchFactory::GetInstance() {
 
 // static
 void TouchFactory::SetTouchDeviceListFromCommandLine() {
+#if defined(TOOLKIT_VIEWS)
   // Get a list of pointer-devices that should be treated as touch-devices.
   // This is primarily used for testing/debugging touch-event processing when a
   // touch-device isn't available.
@@ -75,6 +79,7 @@ void TouchFactory::SetTouchDeviceListFromCommandLine() {
     }
     ui::TouchFactory::GetInstance()->SetTouchDeviceList(device_ids);
   }
+#endif
 }
 
 void TouchFactory::UpdateDeviceList(Display* display) {
@@ -224,6 +229,7 @@ bool TouchFactory::IsMultiTouchDevice(unsigned int deviceid) const {
           false;
 }
 
+#if defined(USE_XI2_MT)
 bool TouchFactory::QuerySlotForTrackingID(uint32 tracking_id, int* slot) {
   if (!id_generator_.HasGeneratedIDFor(tracking_id))
     return false;
@@ -237,6 +243,17 @@ int TouchFactory::GetSlotForTrackingID(uint32 tracking_id) {
 
 void TouchFactory::ReleaseSlotForTrackingID(uint32 tracking_id) {
   id_generator_.ReleaseNumber(tracking_id);
+}
+#endif
+
+bool TouchFactory::IsSlotUsed(int slot) const {
+  CHECK_LT(slot, kMaxTouchPoints);
+  return slots_used_[slot];
+}
+
+void TouchFactory::SetSlotUsed(int slot, bool used) {
+  CHECK_LT(slot, kMaxTouchPoints);
+  slots_used_[slot] = used;
 }
 
 bool TouchFactory::IsTouchDevicePresent() {

--- a/ui/events/x/touch_factory_x11.h
+++ b/ui/events/x/touch_factory_x11.h
@@ -57,6 +57,7 @@ class EVENTS_EXPORT TouchFactory {
   // below for more explanation.)
   bool IsMultiTouchDevice(unsigned int deviceid) const;
 
+#if defined(USE_XI2_MT)
   // Tries to find an existing slot ID mapping to tracking ID. Returns true
   // if the slot is found and it is saved in |slot|, false if no such slot
   // can be found.
@@ -68,6 +69,13 @@ class EVENTS_EXPORT TouchFactory {
 
   // Releases the slot ID mapping to tracking ID.
   void ReleaseSlotForTrackingID(uint32 tracking_id);
+#endif
+
+  // Is the slot ID currently used?
+  bool IsSlotUsed(int slot) const;
+
+  // Marks a slot as being used/unused.
+  void SetSlotUsed(int slot, bool used);
 
   // Whether any touch device is currently present and enabled.
   bool IsTouchDevicePresent();
@@ -113,7 +121,12 @@ class EVENTS_EXPORT TouchFactory {
   // Maximum simultaneous touch points.
   static const int kMaxTouchPoints = 32;
 
+#if defined(USE_XI2_MT)
   SequentialIDGenerator id_generator_;
+#endif
+
+  // A lookup table for slots in use for a touch event.
+  std::bitset<kMaxTouchPoints> slots_used_;
 
   DISALLOW_COPY_AND_ASSIGN(TouchFactory);
 };


### PR DESCRIPTION
Revert "x11: Fix a few touch-event related issues:"

This reverts Chromium commit f8a9520395d7a1e478e6f134d1bb016f45087d00.

[Tizen][Temp] Re-enable pinch zoom in Tizen 2.X.

Chromium had hack to emulate multi touch using XIButton events. However,
unfortunately, above commit dropped the hack, because Chromium officially
supports XInput 2.2 or above.

Tizen 2.X has used the hack because Tizen 2.X does not support XInput2.2 touch
event.
In detail,
1) Tizen 2.1 supports XInput2.1.
2) Tizen 2.2.1 supports XInput2.2, but uses XI_Button event instead of XI_Touch
event.

Temp:
So this PR reverts the commit to support multi touch to Tizen 2.X. If we bump
up to Tizen 3.0, this commit can be removed.

BUG=https://crosswalk-project.org/jira/browse/XWALK-445
