### PR TITLE
[Linux] Enabling Hardware Acceleration with Libva in linux-x86.

### DIFF
--- a/content/common/gpu/media/gpu_video_decode_accelerator.cc
+++ b/content/common/gpu/media/gpu_video_decode_accelerator.cc
@@ -27,7 +27,7 @@
 #include "content/common/gpu/media/dxva_video_decode_accelerator.h"
 #elif defined(OS_CHROMEOS) && defined(ARCH_CPU_ARMEL) && defined(USE_X11)
 #include "content/common/gpu/media/exynos_video_decode_accelerator.h"
-#elif defined(OS_CHROMEOS) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
+#elif defined(OS_LINUX) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
 #include "ui/gl/gl_context_glx.h"
 #include "content/common/gpu/media/vaapi_video_decode_accelerator.h"
 #elif defined(OS_ANDROID)
@@ -277,7 +277,7 @@ void GpuVideoDecodeAccelerator::Initialize(
       weak_factory_for_io_.GetWeakPtr(),
       make_context_current_,
       io_message_loop_));
-#elif defined(OS_CHROMEOS) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
+#elif defined(OS_LINUX) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
   gfx::GLContextGLX* glx_context =
       static_cast<gfx::GLContextGLX*>(stub_->decoder()->GetGLContext());
   GLXContext glx_context_handle =

--- a/content/content_common.gypi
+++ b/content/content_common.gypi
@@ -516,7 +516,10 @@
         ],
       },
     }],
-    ['target_arch != "arm" and chromeos == 1 and use_x11 == 1', {
+    ['target_arch != "arm" and OS == "linux" and use_x11 == 1', {
+      'dependencies': [
+        '../media/media.gyp:media',
+      ],
       'sources': [
         'common/gpu/media/h264_dpb.cc',
         'common/gpu/media/h264_dpb.h',

--- a/content/content_gpu.gypi
+++ b/content/content_gpu.gypi
@@ -74,7 +74,7 @@
         },
       ],
     }],
-    ['target_arch!="arm" and chromeos == 1', {
+    ['target_arch!="arm" and OS=="linux"', {
       'include_dirs': [
         '<(DEPTH)/third_party/libva',
       ],

--- a/content/gpu/gpu_main.cc
+++ b/content/gpu/gpu_main.cc
@@ -42,7 +42,7 @@
 #include "sandbox/win/src/sandbox.h"
 #elif defined(OS_CHROMEOS) && defined(ARCH_CPU_ARMEL) && defined(USE_X11)
 #include "content/common/gpu/media/exynos_video_decode_accelerator.h"
-#elif defined(OS_CHROMEOS) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
+#elif defined(OS_LINUX) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
 #include "content/common/gpu/media/vaapi_wrapper.h"
 #endif
 
@@ -360,7 +360,7 @@ bool WarmUpSandbox(const CommandLine& command_line) {
 
 #if defined(OS_CHROMEOS) && defined(ARCH_CPU_ARMEL) && defined(USE_X11)
   ExynosVideoDecodeAccelerator::PreSandboxInitialization();
-#elif defined(OS_CHROMEOS) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
+#elif defined(OS_LINUX) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
   VaapiWrapper::PreSandboxInitialization();
 #endif
 


### PR DESCRIPTION
```
This commit is not upstreamable.

Currently, VAAPI only enabled for ChromeOS and Windows on
upstream. Although the ChromeOS uses same libva API as
common linux world, upstream refuesed to enable it for linux
common with maintainence concern. Refer to
"https://codereview.chromium.org/16430003/" for more details.

Upstream confirm VAVDA will continue to be restricted to
CrOS/X86 for dev & testing only and not for chromium road map.
So we maintain it for Crosswalk and that will benifit
linux with VAAPI installed and includes Tizen.
```
