### PR TITLE
[Android] Allow use non Activity context to create ContentVideoView

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/ContentVideoView.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ContentVideoView.java
@@ -4,7 +4,6 @@
 
 package org.chromium.content.browser;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -576,11 +575,6 @@ public class ContentVideoView
     private static ContentVideoView createContentVideoView(
             Context context, int nativeContentVideoView, ContentVideoViewClient client) {
         ThreadUtils.assertOnUiThread();
-        // The context needs be Activity to create the ContentVideoView correctly.
-        if (!(context instanceof Activity)) {
-            Log.w(TAG, "Wrong type of context, can't create fullscreen video");
-            return null;
-        }
         return new ContentVideoView(context, nativeContentVideoView, client);
     }
 


### PR DESCRIPTION
ContentVideoView is making an assertion that the context used to create
it is an Activiy, which xwalk doesn't meet. So xwalk crashes when
trying to fullscreen a video.

Why upstream makes the assertion:
ContentVideoView will use context to getSystemService(WINDOW_SERVICE),
which requires an Activity context.

Why xwalk can work as well as break the assertion:
In xwalk case, it's using a MixContext which although the base context
is not an Activity, but the getSystemService call will be bridged to
an Activity finally.

Why can't this be upstreamed:
The real assertion is getSystemService must be called on an Activity,
upstream uses the equivalence that the context should be an Activity
is reasonable for most cases.

For more detail discussion, please refer upstream CL at:
https://codereview.chromium.org/67763004/

Since there's no easy way to detect whether the WindowManager got from
the Context is good or not, this patch to remove the assertion have
to stay in our fork.

BUG=https://crosswalk-project.org/jira/browse/XWALK-171
