### PR TITLE
[Android] Backport Chromium r237215

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/ContentViewGestureHandler.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ContentViewGestureHandler.java
@@ -1143,11 +1143,13 @@ class ContentViewGestureHandler implements LongPressDelegate {
 
     private boolean sendGesture(
             int type, long timeMs, int x, int y, Bundle extraParams) {
+        assert timeMs != 0;
         return mMotionEventDelegate.sendGesture(type, timeMs, x, y, extraParams);
     }
 
     private boolean sendGestureAndRequestVSync(
             int type, long timeMs, int x, int y, Bundle extraParams) {
+        assert timeMs != 0;
         // VSync should only be signalled if the sent gesture was generated from a touch event.
         mSentGestureNeedsVSync = mInputEventsDeliveredAtVSync && mTouchEventHandlingStackDepth > 0;
         mLastVSyncGestureTimeMs = timeMs;

--- a/content/public/android/java/src/org/chromium/content/browser/ZoomManager.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ZoomManager.java
@@ -18,6 +18,10 @@ class ZoomManager {
 
     private ContentViewCore mContentViewCore;
 
+    // ScaleGestureDetector previous to 4.2.2 failed to record touch event times (b/7626515),
+    // so we record them manually for use when synthesizing pinch gestures.
+    private long mCurrentEventTime;
+
     private class ScaleGestureListener implements ScaleGestureDetector.OnScaleGestureListener {
         // Completely silence scaling events. Used in WebView when zoom support
         // is turned off.
@@ -28,6 +32,13 @@ class ZoomManager {
 
         // Whether any pinch zoom event has been sent to native.
         private boolean mPinchEventSent;
+
+        long getEventTime(ScaleGestureDetector detector) {
+            // Workaround for b/7626515, fixed in 4.2.2.
+            assert mCurrentEventTime != 0;
+            assert detector.getEventTime() == 0 || detector.getEventTime() == mCurrentEventTime;
+            return mCurrentEventTime;
+        }
 
         boolean getPermanentlyIgnoreDetectorEvents() {
             return mPermanentlyIgnoreDetectorEvents;
@@ -56,7 +67,7 @@ class ZoomManager {
         @Override
         public void onScaleEnd(ScaleGestureDetector detector) {
             if (!mPinchEventSent || !mContentViewCore.isAlive()) return;
-            mContentViewCore.getContentViewGestureHandler().pinchEnd(detector.getEventTime());
+            mContentViewCore.getContentViewGestureHandler().pinchEnd(getEventTime(detector));
             mPinchEventSent = false;
         }
 
@@ -70,12 +81,12 @@ class ZoomManager {
             // that pinchBy() is called without any pinchBegin().
             // To solve this problem, we call pinchBegin() here if it is never called.
             if (!mPinchEventSent) {
-                mContentViewCore.getContentViewGestureHandler().pinchBegin(detector.getEventTime(),
+                mContentViewCore.getContentViewGestureHandler().pinchBegin(getEventTime(detector),
                         (int) detector.getFocusX(), (int) detector.getFocusY());
                 mPinchEventSent = true;
             }
             mContentViewCore.getContentViewGestureHandler().pinchBy(
-                    detector.getEventTime(), (int) detector.getFocusX(), (int) detector.getFocusY(),
+                    getEventTime(detector), (int) detector.getFocusX(), (int) detector.getFocusY(),
                     detector.getScaleFactor());
             return true;
         }
@@ -106,6 +117,7 @@ class ZoomManager {
     // of processing, if any.
     void passTouchEventThrough(MotionEvent event) {
         mMultiTouchListener.setTemporarilyIgnoreDetectorEvents(true);
+        mCurrentEventTime = event.getEventTime();
         try {
             mMultiTouchDetector.onTouchEvent(event);
         } catch (Exception e) {
@@ -120,6 +132,7 @@ class ZoomManager {
     boolean processTouchEvent(MotionEvent event) {
         // TODO: Need to deal with multi-touch transition
         mMultiTouchListener.setTemporarilyIgnoreDetectorEvents(false);
+        mCurrentEventTime = event.getEventTime();
         try {
             boolean inGesture = isScaleGestureDetectionInProgress();
             boolean retVal = mMultiTouchDetector.onTouchEvent(event);


### PR DESCRIPTION
This is to fix crash when multi touch on Android devices
previous to 4.2.2.

Origin commit log:
    [Android] Record MotionEvent times for pre-4.2.2 ScaleGestureDetector bug.

```
Android's pre-4.2.2 ScaleGestureDetector failed to properly record MotionEvent
times.  This leads to problems, as the detector's event time is used to assign
the synthesized gesture event time.  Record the MotionEvent time prior to
feeding it to the ScaleGestureDetector.

BUG=323108

Review URL: https://codereview.chromium.org/85453004
git-svn-id: svn://svn.chromium.org/chrome/trunk/src@237215 0039d316-1c4b-4281-b951-d872f2087c98
```

BUG=https://crosswalk-project.org/jira/browse/XWALK-458
