### PR TITLE
[Temp] Backport Chromium r236822.

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -3494,7 +3494,7 @@
               # unspecified what the cwd is when running the compiler,
               # so the normal gyp path-munging fails us.  This hack
               # gets the right path.
-              '-B<(PRODUCT_DIR)/../../third_party/gold',
+              '-B<!(cd <(DEPTH) && pwd -P)/third_party/gold',
             ],
           }],
         ],


### PR DESCRIPTION
This is required for XWALK-454 and should help with out-of-source Tizen 
builds: after M32 we generate all build system-related files outside the 
source tree, and the path to the linker needs to be absolute for that to work.

Original commit message:

  Pass the gold binary to the linker using only absolute paths.

  The previous expansion using <(PRODUCT_DIR)/../.. did not work correctly
  if one was using a different build directory layout (out-of-source builds,
  or some build directory with a different number of subdirectories).

  Solve this by doing the same as the sysroot variables: stop using relative
  paths from the build directory and extract absolute paths using DEPTH.

  TEST=./build/gyp_chromium -Goutput_dir=/somewhere/else
  R=phajdan.jr@chromium.org,thakis@chromium.org,dpranke@chromium.org

  Review URL: https://codereview.chromium.org/83673002

BUG=https://crosswalk-project.org/jira/browse/XWALK-454
