### PR TITLE
[SysApps] Expose ffmpeg function signatures needed by Device Capabilities API

### DIFF
--- a/media/base/media_posix.cc
+++ b/media/base/media_posix.cc
@@ -15,6 +15,7 @@
 
 using third_party_ffmpeg::kNumStubModules;
 using third_party_ffmpeg::kModuleFfmpegsumo;
+using third_party_ffmpeg::kModuleXwalk_ffmpegsumo;
 using third_party_ffmpeg::InitializeStubs;
 using third_party_ffmpeg::StubPathMap;
 
@@ -49,8 +50,9 @@ bool InitializeMediaLibraryInternal(const base::FilePath& module_dir) {
   StubPathMap paths;
 
   // First try to initialize with Chrome's sumo library.
-  DCHECK_EQ(kNumStubModules, 1);
+  DCHECK_EQ(kNumStubModules, 2);
   paths[kModuleFfmpegsumo].push_back(module_dir.Append(kSumoLib).value());
+  paths[kModuleXwalk_ffmpegsumo].push_back(module_dir.Append(kSumoLib).value());
 
   // If that fails, see if any system libraries are available.
   paths[kModuleFfmpegsumo].push_back(module_dir.Append(
@@ -58,6 +60,12 @@ bool InitializeMediaLibraryInternal(const base::FilePath& module_dir) {
   paths[kModuleFfmpegsumo].push_back(module_dir.Append(
       FILE_PATH_LITERAL(DSO_NAME("avcodec", AVCODEC_VERSION))).value());
   paths[kModuleFfmpegsumo].push_back(module_dir.Append(
+      FILE_PATH_LITERAL(DSO_NAME("avformat", AVFORMAT_VERSION))).value());
+  paths[kModuleXwalk_ffmpegsumo].push_back(module_dir.Append(
+      FILE_PATH_LITERAL(DSO_NAME("avutil", AVUTIL_VERSION))).value());
+  paths[kModuleXwalk_ffmpegsumo].push_back(module_dir.Append(
+      FILE_PATH_LITERAL(DSO_NAME("avcodec", AVCODEC_VERSION))).value());
+  paths[kModuleXwalk_ffmpegsumo].push_back(module_dir.Append(
       FILE_PATH_LITERAL(DSO_NAME("avformat", AVFORMAT_VERSION))).value());
 
   return InitializeStubs(paths);

--- a/tools/generate_stubs/generate_stubs.py
+++ b/tools/generate_stubs/generate_stubs.py
@@ -1111,9 +1111,32 @@ def CreatePosixStubsForSigFiles(sig_files, stub_name, out_dir,
     header_file.close()
 
 
+# Sometimes additional signatures other than what is exposed to Chromium are
+# needed, in particular for ffmpeg. If we ever make a fork of ffmpeg, is
+# probably a good idea to remove this patch and add the signatures directly on
+# the .sigs file at the dependency repository. In order to expose additional
+# signatures of a library foobar, just add a .sig file prefixed with "xwalk_" at
+# the root folder of the directory containing this script.
+def AddCrosswalkSignatures(sig_files):
+  crosswalk_sig_dir = os.path.dirname(os.path.realpath(__file__))
+  crosswalk_sig_files = []
+
+  for sig_file in sig_files:
+    sig_file_basename = os.path.basename(sig_file)
+    crosswalk_sig_file = os.path.join(crosswalk_sig_dir,
+                                      'xwalk_' + sig_file_basename)
+
+    if os.path.exists(crosswalk_sig_file):
+      crosswalk_sig_files.append(crosswalk_sig_file)
+
+  sig_files.extend(crosswalk_sig_files)
+
+
 def main():
   options, args = ParseOptions()
   out_dir, intermediate_dir = CreateOutputDirectories(options)
+
+  AddCrosswalkSignatures(args)
 
   if options.type == FILE_TYPE_WIN_X86:
     CreateWindowsLibForSigFiles(args, out_dir, intermediate_dir, 'X86')

--- a/tools/generate_stubs/xwalk_ffmpegsumo.sigs
+++ b/tools/generate_stubs/xwalk_ffmpegsumo.sigs
@@ -1,0 +1,8 @@
+# Copyright (c) 2013 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+AVCodec *av_codec_next(const AVCodec *c);
+int av_codec_is_encoder(const AVCodec *c);
+int av_codec_is_decoder(const AVCodec *c);
+AVInputFormat *av_iformat_next(AVInputFormat *f);


### PR DESCRIPTION
We need these functions in to get the list of Codecs available in the
system for getAVCodecs(). If we ever fork ffmpeg, we can just remove
this patch and add the signatures directly at the ffmpeg's signature
list.
