### PR TITLE
[Tizen][Performance] Enable Accelerated 2D Canvas.

### DIFF
--- a/gpu/config/gpu_info_collector_x11.cc
+++ b/gpu/config/gpu_info_collector_x11.cc
@@ -173,7 +173,7 @@ bool CollectContextGraphicsInfo(GPUInfo* gpu_info) {
           switches::kGpuNoContextLost)) {
     gpu_info->can_lose_context = false;
   } else {
-#if defined(OS_CHROMEOS)
+#if defined(OS_CHROMEOS) || defined(OS_TIZEN_MOBILE)
     gpu_info->can_lose_context = false;
 #else
     // TODO(zmo): need to consider the case where we are running on top


### PR DESCRIPTION
If GPU context can be lost, Accelerated 2D Canvas is disabled, because there is
no way to recover Accelerated 2D Canvas when GPU crashes. Currently, only EGL
backend marks GPUInfo::can_lose_context true (means Accelerated 2D Canvas cannot
be enabled). However, interestingly, Android and ChromeOS mark it false to take
advantage of Accelerated 2D Canvas without fallback solution. They just take a
risk.

So Tizen also takes a risk like Android and ChromeOS. It is worth to do it
because performance improvement is very significant (2~3 times).

Measurement data:
1. http://www.craftymind.com/factory/guimark3/vector/GM3_JS_Vector.html
Software Canvas : 14.91 FPS
Accelerated 2D Canvas : 44.82 FPS
2. http://www.craftymind.com/factory/guimark3/bitmap/GM3_JS_Bitmap.html
Software Canvas : 17.16 FPS
Accelerated 2D Canvas : 54.58 FPS
3. http://www.craftymind.com/factory/guimark3/compute/GM3_JS_Compute.html
Software Canvas : 19.36 FPS
Accelerated 2D Canvas : 39.18 FPS

BUG=https://crosswalk-project.org/jira/browse/XWALK-531,
https://crosswalk-project.org/jira/browse/XWALK-73
