### PR TITLE
[Tizen] Use 'dlopen' to load the camera driver

### DIFF
--- a/media/media.gyp
+++ b/media/media.gyp
@@ -587,11 +587,6 @@
                 # defined for Tizen environment, otherwise there are compiler errors.
                 '-D__user=',
               ],
-              'link_settings': {
-                'libraries': [
-                  '<!@(<(pkg-config) --libs gstreamer-0.10 gstreamer-atomisphal-0.10)',
-                ],
-              },
             }],
             ['use_x11==1', {
               'link_settings': {


### PR DESCRIPTION
The camera driver package 'gst-plugins-atomisp' is platform specific for PR3,
and not available on emulator. Currently crosswalk links to the driver libraries
at build time. This leads to dependency checking error when installing crosswalk
on emulator. To overcome this issue, we instead have to use 'dlopen' to load the
driver libraries at runtime.

BUG=XWALK-460
