### PR TITLE
Fix default min-layout width and scrollbar appearence.

### DIFF
--- a/content/renderer/web_preferences.cc
+++ b/content/renderer/web_preferences.cc
@@ -326,6 +326,10 @@ void ApplyWebPreferences(const WebPreferences& prefs, WebView* web_view) {
 
   settings->setSelectionIncludesAltImageText(true);
 
+  // Crosswalk shared settings:
+  settings->setLayoutFallbackWidth(0);
+  settings->setMainFrameClipsContent(false);
+
 #if defined(OS_TIZEN)
   // Scrollbars should not be stylable.
   settings->setAllowCustomScrollbarInMainFrame(false);


### PR DESCRIPTION
Fix the default min-layout width which is used when no viewport meta
is present. Is is now 0, meaning the window viewport width will always
be used.

Fix scrollbar lengths so that they match up with the size of the content.
