### PR TITLE
[Tizen] Use Tizen system location provider for geolocation subsystem

### DIFF
--- a/content/browser/geolocation/location_arbitrator_impl.cc
+++ b/content/browser/geolocation/location_arbitrator_impl.cc
@@ -150,7 +150,7 @@ LocationProvider* LocationArbitratorImpl::NewNetworkLocationProvider(
     net::URLRequestContextGetter* context,
     const GURL& url,
     const string16& access_token) {
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) || defined(OS_TIZEN_MOBILE)
   // Android uses its own SystemLocationProvider.
   return NULL;
 #else
@@ -160,7 +160,9 @@ LocationProvider* LocationArbitratorImpl::NewNetworkLocationProvider(
 }
 
 LocationProvider* LocationArbitratorImpl::NewSystemLocationProvider() {
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
+#if defined(OS_TIZEN_MOBILE)
+  return content::NewSystemLocationProvider();
+#elif defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
   return NULL;
 #else
   return content::NewSystemLocationProvider();


### PR DESCRIPTION
This patch enables Tizen geolocation provider, so that it could be
used by chromium geolocation subsystem.
