### PR TITLE
[Android] Set webaudio to be muted when volume is set to 0

### DIFF
--- a/media/audio/android/audio_manager_android.h
+++ b/media/audio/android/audio_manager_android.h
@@ -5,11 +5,16 @@
 #ifndef MEDIA_AUDIO_ANDROID_AUDIO_MANAGER_ANDROID_H_
 #define MEDIA_AUDIO_ANDROID_AUDIO_MANAGER_ANDROID_H_
 
+#include <set>
+
 #include "base/android/jni_android.h"
 #include "base/gtest_prod_util.h"
+#include "base/synchronization/lock.h"
 #include "media/audio/audio_manager_base.h"
 
 namespace media {
+
+class OpenSLESOutputStream;
 
 // Android implemention of AudioManager.
 class MEDIA_EXPORT AudioManagerAndroid : public AudioManagerBase {
@@ -52,6 +57,8 @@ class MEDIA_EXPORT AudioManagerAndroid : public AudioManagerBase {
 
   static bool RegisterAudioManager(JNIEnv* env);
 
+  void SetMute(JNIEnv* env, jobject obj, jboolean muted);
+
  protected:
   virtual ~AudioManagerAndroid();
 
@@ -68,11 +75,20 @@ class MEDIA_EXPORT AudioManagerAndroid : public AudioManagerBase {
   int GetAudioLowLatencyOutputFrameSize();
   int GetOptimalOutputFrameSize(int sample_rate, int channels);
 
+  void DoSetMuteOnAudioThread(bool muted);
+
   // Allow the AudioAndroidTest to access private methods.
   FRIEND_TEST_ALL_PREFIXES(AudioAndroidTest, IsAudioLowLatencySupported);
 
   // Java AudioManager instance.
   base::android::ScopedJavaGlobalRef<jobject> j_audio_manager_;
+
+  typedef std::set<OpenSLESOutputStream*> OutputStreams;
+  OutputStreams streams_;
+  // TODO(wjia): remove this lock once unit test modules are fixed to call
+  // AudioManager::MakeAudioOutputStream on the audio thread. For now, this
+  // lock is used to guard access to |streams_|.
+  base::Lock streams_lock_;
 
   DISALLOW_COPY_AND_ASSIGN(AudioManagerAndroid);
 };

--- a/media/audio/android/opensles_output.cc
+++ b/media/audio/android/opensles_output.cc
@@ -28,6 +28,7 @@ OpenSLESOutputStream::OpenSLESOutputStream(AudioManagerAndroid* manager,
       active_buffer_index_(0),
       buffer_size_bytes_(0),
       started_(false),
+      muted_(false),
       volume_(1.0) {
   DVLOG(2) << "OpenSLESOutputStream::OpenSLESOutputStream()";
   format_.formatType = SL_DATAFORMAT_PCM;
@@ -170,6 +171,12 @@ void OpenSLESOutputStream::SetVolume(double volume) {
 void OpenSLESOutputStream::GetVolume(double* volume) {
   DCHECK(thread_checker_.CalledOnValidThread());
   *volume = static_cast<double>(volume_);
+}
+
+void OpenSLESOutputStream::SetMute(bool muted) {
+  DVLOG(2) << "OpenSLESOutputStream::SetMute(" << muted << ")";
+  DCHECK(thread_checker_.CalledOnValidThread());
+  muted_ = muted;
 }
 
 bool OpenSLESOutputStream::CreatePlayer() {
@@ -324,7 +331,7 @@ void OpenSLESOutputStream::FillBufferQueueNoLock() {
   // Note: If the internal representation ever changes from 16-bit PCM to
   // raw float, the data must be clipped and sanitized since it may come
   // from an untrusted source such as NaCl.
-  audio_bus_->Scale(volume_);
+  audio_bus_->Scale(muted_ ? 0.0f : volume_);
   audio_bus_->ToInterleaved(frames_filled,
                             format_.bitsPerSample / 8,
                             audio_data_[active_buffer_index_]);

--- a/media/audio/android/opensles_output.h
+++ b/media/audio/android/opensles_output.h
@@ -40,6 +40,10 @@ class OpenSLESOutputStream : public AudioOutputStream {
   virtual void SetVolume(double volume) OVERRIDE;
   virtual void GetVolume(double* volume) OVERRIDE;
 
+  // Set the value of |muted_|. It does not affect |volume_| which can be
+  // got by calling GetVolume(). See comments for |muted_| below.
+  void SetMute(bool muted);
+
  private:
   bool CreatePlayer();
 
@@ -95,6 +99,12 @@ class OpenSLESOutputStream : public AudioOutputStream {
   size_t buffer_size_bytes_;
 
   bool started_;
+
+  // Volume control coming from hardware. It overrides |volume_| when it's
+  // true. Otherwise, use |volume_| for scaling.
+  // This is needed because platform voice volume never goes to zero in
+  // COMMUNICATION mode on Android.
+  bool muted_;
 
   // Volume level from 0 to 1.
   float volume_;


### PR DESCRIPTION
We are using Communication mode for audio backend on Android. By design,
the platform voice volume never goes to zero. This patch uses ContentObserver
to listen to volume change. When volume is set to zero, AudioManagerAndroid
will mute all its output streams.

The patch is back ported from chromium trunk, please see:
https://codereview.chromium.org/93233003
Please remove this patch if chromium is rebased to version 33.

BUG=https://crosswalk-project.org/jira/browse/XWALK-622
