### PR TITLE
[Android] Use application context for shared pref's creation

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/ResourceExtractor.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ResourceExtractor.java
@@ -62,7 +62,8 @@ public class ResourceExtractor {
                 deleteFiles(mContext);
             }
 
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(
+                    mContext.getApplicationContext());
             HashSet<String> filenames = (HashSet<String>) prefs.getStringSet(
                     PAK_FILENAMES, new HashSet<String>());
             String currentLocale = LocalizationUtils.getDefaultLocale();


### PR DESCRIPTION
The shared pref here is to save the status for pak file extraction.
Since the pak file is extracted to each app's data folder, the
prefs also needs to be saved for each app individually.

For crosswalk usage, in shared mode, the context in
ResourceExtractor is the context for library apk. Use the
application context of it to get the app's context.

BUG=https://crosswalk-project.org/jira/browse/XWALK-228
