### PR TITLE
Make CodecIDToAudioCodec and CodecIDToVideoCodec available as global functions

### DIFF
--- a/media/ffmpeg/ffmpeg_common.cc
+++ b/media/ffmpeg/ffmpeg_common.cc
@@ -60,7 +60,7 @@ int64 ConvertToTimeBase(const AVRational& time_base,
 }
 
 // Converts an FFmpeg audio codec ID into its corresponding supported codec id.
-static AudioCodec CodecIDToAudioCodec(AVCodecID codec_id) {
+AudioCodec CodecIDToAudioCodec(AVCodecID codec_id) {
   switch (codec_id) {
     case AV_CODEC_ID_AAC:
       return kCodecAAC;
@@ -141,7 +141,7 @@ static AVCodecID AudioCodecToCodecID(AudioCodec audio_codec,
 }
 
 // Converts an FFmpeg video codec ID into its corresponding supported codec id.
-static VideoCodec CodecIDToVideoCodec(AVCodecID codec_id) {
+VideoCodec CodecIDToVideoCodec(AVCodecID codec_id) {
   switch (codec_id) {
     case AV_CODEC_ID_H264:
       return kCodecH264;

--- a/media/ffmpeg/ffmpeg_common.h
+++ b/media/ffmpeg/ffmpeg_common.h
@@ -126,6 +126,10 @@ VideoFrame::Format PixelFormatToVideoFormat(PixelFormat pixel_format);
 // Converts video formats to its corresponding FFmpeg's pixel formats.
 PixelFormat VideoFormatToPixelFormat(VideoFrame::Format video_format);
 
+AudioCodec CodecIDToAudioCodec(AVCodecID codec_id);
+
+VideoCodec CodecIDToVideoCodec(AVCodecID codec_id);
+
 }  // namespace media
 
 #endif  // MEDIA_FFMPEG_FFMPEG_COMMON_H_


### PR DESCRIPTION
Make CodecIDToAudioCodec and CodecIDToVideoCodec available as global
functions, so that they can be used by Device Capabilities getAVCodecs()
interface to query the list of supported codecs.

These utility functions converts an FFmpeg audio codec ID into its corresponding
supported codec id.
