### PR TITLE
[SysApps] Add MEDIA_EXPORT to fix linking errors in the component build

### DIFF
--- a/media/ffmpeg/ffmpeg_common.h
+++ b/media/ffmpeg/ffmpeg_common.h
@@ -126,9 +126,9 @@ VideoFrame::Format PixelFormatToVideoFormat(PixelFormat pixel_format);
 // Converts video formats to its corresponding FFmpeg's pixel formats.
 PixelFormat VideoFormatToPixelFormat(VideoFrame::Format video_format);
 
-AudioCodec CodecIDToAudioCodec(AVCodecID codec_id);
+MEDIA_EXPORT AudioCodec CodecIDToAudioCodec(AVCodecID codec_id);
 
-VideoCodec CodecIDToVideoCodec(AVCodecID codec_id);
+MEDIA_EXPORT VideoCodec CodecIDToVideoCodec(AVCodecID codec_id);
 
 }  // namespace media
 


### PR DESCRIPTION
Add MEDIA_EXPORT for CodecIDToAudioCodec and CodecIDToVideoCodec to fix
linking errors in the component build. This was missed from the last change.
