### PR TITLE
[SysApps] Expose ffmpeg function signatures needed by Device Capabilities API

### DIFF
--- a/media/base/media_posix.cc
+++ b/media/base/media_posix.cc
@@ -15,7 +15,6 @@
 
 using third_party_ffmpeg::kNumStubModules;
 using third_party_ffmpeg::kModuleFfmpegsumo;
-using third_party_ffmpeg::kModuleXwalk_ffmpegsumo;
 using third_party_ffmpeg::InitializeStubs;
 using third_party_ffmpeg::StubPathMap;
 
@@ -50,9 +49,8 @@ bool InitializeMediaLibraryInternal(const base::FilePath& module_dir) {
   StubPathMap paths;
 
   // First try to initialize with Chrome's sumo library.
-  DCHECK_EQ(kNumStubModules, 2);
+  DCHECK_EQ(kNumStubModules, 1);
   paths[kModuleFfmpegsumo].push_back(module_dir.Append(kSumoLib).value());
-  paths[kModuleXwalk_ffmpegsumo].push_back(module_dir.Append(kSumoLib).value());
 
   // If that fails, see if any system libraries are available.
   paths[kModuleFfmpegsumo].push_back(module_dir.Append(
@@ -60,12 +58,6 @@ bool InitializeMediaLibraryInternal(const base::FilePath& module_dir) {
   paths[kModuleFfmpegsumo].push_back(module_dir.Append(
       FILE_PATH_LITERAL(DSO_NAME("avcodec", AVCODEC_VERSION))).value());
   paths[kModuleFfmpegsumo].push_back(module_dir.Append(
-      FILE_PATH_LITERAL(DSO_NAME("avformat", AVFORMAT_VERSION))).value());
-  paths[kModuleXwalk_ffmpegsumo].push_back(module_dir.Append(
-      FILE_PATH_LITERAL(DSO_NAME("avutil", AVUTIL_VERSION))).value());
-  paths[kModuleXwalk_ffmpegsumo].push_back(module_dir.Append(
-      FILE_PATH_LITERAL(DSO_NAME("avcodec", AVCODEC_VERSION))).value());
-  paths[kModuleXwalk_ffmpegsumo].push_back(module_dir.Append(
       FILE_PATH_LITERAL(DSO_NAME("avformat", AVFORMAT_VERSION))).value());
 
   return InitializeStubs(paths);

--- a/tools/generate_stubs/generate_stubs.py
+++ b/tools/generate_stubs/generate_stubs.py
@@ -378,7 +378,7 @@ def ExtractModuleName(infile_path):
   return basename
 
 
-def ParseSignatures(infile):
+def ParseSignaturesReal(infile):
   """Parses function signatures in the input file.
 
   This function parses a file of signatures into a list of dictionaries that
@@ -419,6 +419,27 @@ def ParseSignatures(infile):
           {'return_type': m.group('return_type').strip(),
            'name': m.group('name').strip(),
            'params': [arg.strip() for arg in m.group('params').split(',')]})
+  return signatures
+
+
+# Sometimes additional signatures other than what is exposed to Chromium are
+# needed, in particular for ffmpeg. If we ever make a fork of ffmpeg, is
+# probably a good idea to remove this patch and add the signatures directly on
+# the .sigs file at the dependency repository. In order to expose additional
+# signatures of a library foobar, just add a .sig file prefixed with "xwalk_" at
+# the root folder of the directory containing this script.
+def ParseSignatures(infile):
+  signatures = ParseSignaturesReal(infile)
+
+  xwalk_sig_dir = os.path.dirname(os.path.realpath(__file__))
+  xwalk_sig_file = os.path.join(xwalk_sig_dir,
+                                'xwalk_' + os.path.basename(infile.name))
+
+  if os.path.exists(xwalk_sig_file):
+    xwalk_infile = open(xwalk_sig_file, 'r')
+    signatures += ParseSignaturesReal(xwalk_infile)
+    xwalk_infile.close()
+
   return signatures
 
 
@@ -1111,32 +1132,9 @@ def CreatePosixStubsForSigFiles(sig_files, stub_name, out_dir,
     header_file.close()
 
 
-# Sometimes additional signatures other than what is exposed to Chromium are
-# needed, in particular for ffmpeg. If we ever make a fork of ffmpeg, is
-# probably a good idea to remove this patch and add the signatures directly on
-# the .sigs file at the dependency repository. In order to expose additional
-# signatures of a library foobar, just add a .sig file prefixed with "xwalk_" at
-# the root folder of the directory containing this script.
-def AddCrosswalkSignatures(sig_files):
-  crosswalk_sig_dir = os.path.dirname(os.path.realpath(__file__))
-  crosswalk_sig_files = []
-
-  for sig_file in sig_files:
-    sig_file_basename = os.path.basename(sig_file)
-    crosswalk_sig_file = os.path.join(crosswalk_sig_dir,
-                                      'xwalk_' + sig_file_basename)
-
-    if os.path.exists(crosswalk_sig_file):
-      crosswalk_sig_files.append(crosswalk_sig_file)
-
-  sig_files.extend(crosswalk_sig_files)
-
-
 def main():
   options, args = ParseOptions()
   out_dir, intermediate_dir = CreateOutputDirectories(options)
-
-  AddCrosswalkSignatures(args)
 
   if options.type == FILE_TYPE_WIN_X86:
     CreateWindowsLibForSigFiles(args, out_dir, intermediate_dir, 'X86')


### PR DESCRIPTION
WARNING: This is a follow-up patch fixing Windows build. Squash this with the
previous patch with the same name on the next rebase (and remove this warning).

We need these functions in to get the list of Codecs available in the
system for getAVCodecs(). If we ever fork ffmpeg, we can just remove
this patch and add the signatures directly at the ffmpeg's signature
list.
