### PR TITLE
[Temp] Add EGL-specific changes for Wayland.

### DIFF
--- a/ui/gl/gl_surface_egl.cc
+++ b/ui/gl/gl_surface_egl.cc
@@ -117,8 +117,7 @@ bool GLSurfaceEGL::InitializeOneOff() {
     LOG(ERROR) << "OZONE failed to initialize hardware";
     return false;
   }
-  g_native_display = reinterpret_cast<EGLNativeDisplayType>(
-      surface_factory->GetNativeDisplay());
+  g_native_display = surface_factory->GetNativeDisplay();
 #else
   g_native_display = EGL_DEFAULT_DISPLAY;
 #endif
@@ -749,7 +748,7 @@ GLSurface::CreateOffscreenGLSurface(const gfx::Size& size) {
     case kGLImplementationEGLGLES2: {
       scoped_refptr<GLSurface> surface;
       if (g_egl_surfaceless_context_supported &&
-         (size.width() == 0 && size.height() == 0)) {
+         (size.width() == 1 && size.height() == 1)) {
         surface = new SurfacelessEGL(size);
       } else
         surface = new PbufferGLSurfaceEGL(size);


### PR DESCRIPTION
The original commit comes from the ozone-wayland repository
(https://github.com/01org/ozone-wayland).

  From: Kondapally Kalyan kalyan.kondapally@intel.com

  This patch adds following two snips, respectively giving support:
 1)EGLNativeDisplayType adjustment and khronos header. More info:
   https://code.google.com/p/chromium/issues/detail?id=266310
 2)OffScreen-rendering support for use cases like WebGL and
   Canvas2D. This should be enabled in upstream but needs some
   cross platform support before it can be done.
   More info: https://codereview.chromium.org/49533003/

It is required for proper Ozone-Wayland support. The Ozone-Wayland team will 
take care of upstreaming it.
