### PR TITLE
[Views] Customize _NET_WM_PID for X11 window backing a Widget

### DIFF
--- a/ui/views/widget/desktop_aura/desktop_root_window_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_root_window_host_x11.cc
@@ -953,7 +953,9 @@ void DesktopRootWindowHostX11::InitX11Window(
   // program to kill if the window hangs.
   // XChangeProperty() expects "pid" to be long.
   COMPILE_ASSERT(sizeof(long) >= sizeof(pid_t), pid_t_bigger_than_long);
-  long pid = getpid();
+  long pid = params.net_wm_pid;
+  if (!pid)
+    pid = getpid();
   XChangeProperty(xdisplay_,
                   xwindow_,
                   atom_cache_.GetAtom("_NET_WM_PID"),

--- a/ui/views/widget/widget.cc
+++ b/ui/views/widget/widget.cc
@@ -129,7 +129,8 @@ Widget::InitParams::InitParams()
       desktop_root_window_host(NULL),
       top_level(false),
       layer_type(ui::LAYER_TEXTURED),
-      context(NULL) {
+      context(NULL),
+      net_wm_pid(0) {
 }
 
 Widget::InitParams::InitParams(Type type)
@@ -155,7 +156,8 @@ Widget::InitParams::InitParams(Type type)
       desktop_root_window_host(NULL),
       top_level(false),
       layer_type(ui::LAYER_TEXTURED),
-      context(NULL) {
+      context(NULL),
+      net_wm_pid(0) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ui/views/widget/widget.h
+++ b/ui/views/widget/widget.h
@@ -231,6 +231,9 @@ class VIEWS_EXPORT Widget : public internal::NativeWidgetDelegate,
     // window grouping and desktop file matching in Linux window managers.
     std::string wm_class_name;
     std::string wm_class_class;
+    // Only used by X11, for root level windows. Specifies the PID set in
+    // _NET_WM_PID window property.
+    long net_wm_pid;
   };
 
   Widget();


### PR DESCRIPTION
This patch allow us to customize the _NET_WM_PID property of a X11
window that is backing a views::Widget. A new attribute was added to
InitParams that contains the new value, if not set, the PID of the
current running process is used.

The reason for having this ability is to make Task Manager able to
raise the right X11 window when one "running application" is selected.

In Tizen Mobile, we use a shared browser process, that will create all
the windows, and the homescreen launches a different program that will
trigger the launch in the shared browser process. To make Task Manager
work properly we need to set the _NET_WM_PID of the windows we create to
the appropriate PID of the program

Since both Linux Desktop and Tizen Mobile use the
DesktopRootWindowHostX11, we don't change RootWindowHostX11.
