### PR TITLE
[Tizen][GPU][Perf] Prevent GPU scheduler from thrashiing.

### DIFF
--- a/gpu/command_buffer/client/cmd_buffer_helper.cc
+++ b/gpu/command_buffer/client/cmd_buffer_helper.cc
@@ -245,7 +245,7 @@ void CommandBufferHelper::WaitForAvailableEntries(int32 count) {
     Flush();
   } else if (flush_automatically_ &&
              (commands_issued_ % kCommandsPerFlushCheck == 0)) {
-#if !defined(OS_ANDROID)
+#if !(defined(OS_ANDROID) || defined(OS_TIZEN_MOBILE))
     // Allow this command buffer to be pre-empted by another if a "reasonable"
     // amount of work has been done. On highend machines, this reduces the
     // latency of GPU commands. However, on Android, this can cause the


### PR DESCRIPTION
This PR turns off pre-empty scheduling. On highend machines, pre-empty scheduling reduces
the latency of GPU commands. However, on Tizen mobile, this can cause the kernel
to thrash between generating GPU commands and executing them. Android already
turned off pre-empty scheduling also.

In addition, this PR is related to the private HW issue. Refer to
https://crosswalk-project.org/jira/browse/XWALK-348?focusedCommentId=13435&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13435

BUG=https://crosswalk-project.org/jira/browse/XWALK-348
