### PR TITLE
[Android] Support app scheme in media player

### DIFF
--- a/content/renderer/media/android/webmediaplayer_android.cc
+++ b/content/renderer/media/android/webmediaplayer_android.cc
@@ -610,7 +610,7 @@ void WebMediaPlayerAndroid::OnMediaMetadataChanged(
     const base::TimeDelta& duration, int width, int height, bool success) {
   bool need_to_signal_duration_changed = false;
 
-  if (url_.SchemeIs("file"))
+  if (url_.SchemeIs("file") || url_.SchemeIs("app"))
     UpdateNetworkState(WebMediaPlayer::NetworkStateLoaded);
 
   // Update duration, if necessary, prior to ready state updates that may

--- a/media/base/android/media_player_bridge.cc
+++ b/media/base/android/media_player_bridge.cc
@@ -19,6 +19,9 @@ using base::android::ScopedJavaLocalRef;
 // Time update happens every 250ms.
 static const int kTimeUpdateInterval = 250;
 
+static const char* APP_SCHEME = "app";
+static const std::string FILE_URL_PREFIX = "file:///android_asset/www";
+
 namespace media {
 
 MediaPlayerBridge::MediaPlayerBridge(
@@ -49,6 +52,12 @@ MediaPlayerBridge::~MediaPlayerBridge() {
 }
 
 void MediaPlayerBridge::Initialize() {
+  if (url_.SchemeIs(APP_SCHEME)) {
+    cookies_.clear();
+    ExtractMediaMetadata(FILE_URL_PREFIX + url_.path());
+    return;
+  }
+
   if (url_.SchemeIsFile()) {
     cookies_.clear();
     ExtractMediaMetadata(url_.spec());
@@ -125,7 +134,9 @@ void MediaPlayerBridge::Prepare() {
             url_, base::Bind(&MediaPlayerBridge::SetDataSource,
                              weak_this_.GetWeakPtr()));
   } else {
-    SetDataSource(url_.spec());
+    std::string url = url_.SchemeIs(APP_SCHEME) ?
+        FILE_URL_PREFIX + url_.path() : url_.spec();
+    SetDataSource(url);
   }
 }
 


### PR DESCRIPTION
This a hot fix on the bug that the audio/video can not be loaded
with app scheme.
The resource loading of media player on Android is executed by
Android system media player(setDataSource), which goes a total
different way with other ports(Chromium's own network stack). The
interaction with system media player is in Chromium, so we must do
the modification in Chromium, and can not in xwalk instead.

BUG=https://crosswalk-project.org/jira/browse/XWALK-880
