### PR TITLE
[Android] Fix the crash issue caused by vibrate permission

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/VibrationProvider.java
+++ b/content/public/android/java/src/org/chromium/content/browser/VibrationProvider.java
@@ -7,6 +7,7 @@ package org.chromium.content.browser;
 import android.content.Context;
 import android.media.AudioManager;
 import android.os.Vibrator;
+import android.util.Log;
 
 import org.chromium.base.CalledByNative;
 import org.chromium.base.JNINamespace;
@@ -16,6 +17,7 @@ import org.chromium.base.JNINamespace;
  */
 @JNINamespace("content")
 class VibrationProvider {
+    private static final String TAG = "VibrationProvider";
 
     private final AudioManager mAudioManager;
     private final Vibrator mVibrator;
@@ -27,13 +29,22 @@ class VibrationProvider {
 
     @CalledByNative
     private void vibrate(long milliseconds) {
-        if (mAudioManager.getRingerMode() != AudioManager.RINGER_MODE_SILENT)
-            mVibrator.vibrate(milliseconds);
+        if (mAudioManager.getRingerMode() != AudioManager.RINGER_MODE_SILENT) {
+            try {
+                mVibrator.vibrate(milliseconds);
+            } catch (SecurityException e) {
+                Log.e(TAG, "Caught security exception, requires VIBRATE permission.");
+            }
+        }
     }
 
     @CalledByNative
     private void cancelVibration() {
-        mVibrator.cancel();
+        try {
+            mVibrator.cancel();
+        } catch (SecurityException e) {
+            Log.e(TAG, "Caught security exception, requires VIBRATE permission.");
+        }
     }
 
     private VibrationProvider(Context context) {


### PR DESCRIPTION
The app will be crashed when there is no android.permission.VIBRATE specified, and use vibrate API directly.
Catch the security exception instead of crash should be more friendly.

Bug: XWALK-803
