### PR TITLE
[Android] Add Resource loading filter for MediaPlayer

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/MediaResourceGetter.java
+++ b/content/public/android/java/src/org/chromium/content/browser/MediaResourceGetter.java
@@ -93,6 +93,10 @@ class MediaResourceGetter {
         try {
             Uri uri = Uri.parse(url);
             String scheme = uri.getScheme();
+            // Keep app uri have the same behavior with file asset uri.
+            if (scheme.equals("app")) {
+                return new MediaMetadata(durationInMilliseconds, width, height, success);
+            }
             if (scheme == null || scheme.equals("file")) {
                 File file = new File(uri.getPath());
                 String path = file.getAbsolutePath();

--- a/content/renderer/media/android/webmediaplayer_android.cc
+++ b/content/renderer/media/android/webmediaplayer_android.cc
@@ -4,6 +4,7 @@
 
 #include "content/renderer/media/android/webmediaplayer_android.h"
 
+#include <algorithm>
 #include <limits>
 
 #include "base/bind.h"
@@ -610,7 +611,7 @@ void WebMediaPlayerAndroid::OnMediaMetadataChanged(
     const base::TimeDelta& duration, int width, int height, bool success) {
   bool need_to_signal_duration_changed = false;
 
-  if (url_.SchemeIs("file"))
+  if (url_.SchemeIs("file") || url_.SchemeIs("app"))
     UpdateNetworkState(WebMediaPlayer::NetworkStateLoaded);
 
   // Update duration, if necessary, prior to ready state updates that may

--- a/media/base/android/java/src/org/chromium/media/MediaPlayerBridge.java
+++ b/media/base/android/java/src/org/chromium/media/MediaPlayerBridge.java
@@ -26,6 +26,19 @@ import java.util.Map;
 @JNINamespace("media")
 public class MediaPlayerBridge {
 
+    public static class ResourceLoadingFilter {
+        public boolean shouldOverrideResourceLoading(
+                MediaPlayer mediaPlayer, Context context, Uri uri) {
+            return false;
+        }
+    }
+
+    private static ResourceLoadingFilter sResourceLoadFilter = null;
+
+    public static void setResourceLoadingFilter(ResourceLoadingFilter filter) {
+        sResourceLoadFilter = filter;
+    }
+
     private static final String TAG = "MediaPlayerBridge";
 
     // Local player to forward this to. We don't initialize it here since the subclass might not
@@ -114,6 +127,11 @@ public class MediaPlayerBridge {
         if (!TextUtils.isEmpty(cookies))
             headersMap.put("Cookie", cookies);
         try {
+            if (sResourceLoadFilter != null &&
+                    sResourceLoadFilter.shouldOverrideResourceLoading(
+                            getLocalPlayer(), context, uri)) {
+                return true;
+            }
             getLocalPlayer().setDataSource(context, uri, headersMap);
             return true;
         } catch (Exception e) {

--- a/media/base/android/media_player_bridge.cc
+++ b/media/base/android/media_player_bridge.cc
@@ -49,7 +49,7 @@ MediaPlayerBridge::~MediaPlayerBridge() {
 }
 
 void MediaPlayerBridge::Initialize() {
-  if (url_.SchemeIsFile()) {
+  if (url_.SchemeIsFile() || url_.SchemeIs("app")) {
     cookies_.clear();
     ExtractMediaMetadata(url_.spec());
     return;


### PR DESCRIPTION
Why: There are requirements to customize the MediaPlayer resource
loading on Android which is implemented in Chromium code base.
Till now we have two points:
    1) Support the file:///android_asset in MediaPlayer.
    2) Support app scheme in the resource loading of MediaPlayer.
Unfortunately, the resource loading of MediaPlayer on Andoid goes
a different way from other ports and no interface to handle this.

How: Add a new interface ResourceLoadingFilter to filter the resource
loading(setDataSource) in MediaPlayerBridge, which could be used in
xwalk to do the customization by overriding the function of
shouldOverrideResourceLoading() in xwalk.

BUG=https://crosswalk-project.org/jira/browse/XWALK-880
