### PR TITLE
[SysApps] Compile StorageMonitor as a component

### DIFF
--- a/chrome/browser/storage_monitor/storage_monitor.cc
+++ b/chrome/browser/storage_monitor/storage_monitor.cc
@@ -6,7 +6,9 @@
 
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
+#if !defined(XWALK_STORAGE_MONITOR)
 #include "chrome/browser/browser_process.h"
+#endif
 #include "chrome/browser/storage_monitor/removable_storage_observer.h"
 #include "chrome/browser/storage_monitor/transient_device_ids.h"
 
@@ -43,10 +45,16 @@ void StorageMonitor::ReceiverImpl::MarkInitialized() {
 }
 
 StorageMonitor* StorageMonitor::GetInstance() {
+#if !defined(XWALK_STORAGE_MONITOR)
   if (g_browser_process)
     return g_browser_process->storage_monitor();
 
   return NULL;
+#else
+  static StorageMonitor* monitor(StorageMonitor::Create());
+
+  return monitor;
+#endif
 }
 
 std::vector<StorageInfo> StorageMonitor::GetAllAvailableStorages() const {

--- a/components/components.gyp
+++ b/components/components.gyp
@@ -22,6 +22,7 @@
     'precache.gypi',
     'signin.gypi',
     'startup_metric_utils.gypi',
+    'storage_monitor.gypi',
     'translate.gypi',
     'url_matcher.gypi',
     'user_prefs.gypi',

--- a/components/storage_monitor.gypi
+++ b/components/storage_monitor.gypi
@@ -1,0 +1,65 @@
+{
+  'targets': [
+    {
+      # Build Chromium's StorageMonitor as a static library so we
+      # don't need to reimplement the exact same functionality.
+      # This is being worked upstream on:
+      # https://codereview.chromium.org/152343005/
+      'target_name': 'storage_monitor',
+      'type': 'static_library',
+      'includes' : [
+        '../build/filename_rules.gypi',
+      ],
+      'defines': [
+        'XWALK_STORAGE_MONITOR=1',
+      ],
+      'include_dirs': [
+        '..',
+      ],
+      'sources': [
+        '../chrome/browser/storage_monitor/image_capture_device.h',
+        '../chrome/browser/storage_monitor/image_capture_device.mm',
+        '../chrome/browser/storage_monitor/image_capture_device_manager.h',
+        '../chrome/browser/storage_monitor/image_capture_device_manager.mm',
+        '../chrome/browser/storage_monitor/media_storage_util.cc',
+        '../chrome/browser/storage_monitor/media_storage_util.h',
+        '../chrome/browser/storage_monitor/media_transfer_protocol_device_observer_linux.cc',
+        '../chrome/browser/storage_monitor/media_transfer_protocol_device_observer_linux.h',
+        '../chrome/browser/storage_monitor/mtab_watcher_linux.cc',
+        '../chrome/browser/storage_monitor/mtab_watcher_linux.h',
+        '../chrome/browser/storage_monitor/portable_device_watcher_win.cc',
+        '../chrome/browser/storage_monitor/portable_device_watcher_win.h',
+        '../chrome/browser/storage_monitor/removable_device_constants.cc',
+        '../chrome/browser/storage_monitor/removable_device_constants.h',
+        '../chrome/browser/storage_monitor/removable_storage_observer.h',
+        '../chrome/browser/storage_monitor/storage_info.cc',
+        '../chrome/browser/storage_monitor/storage_info.h',
+        '../chrome/browser/storage_monitor/storage_monitor.cc',
+        '../chrome/browser/storage_monitor/storage_monitor.h',
+        '../chrome/browser/storage_monitor/storage_monitor_linux.cc',
+        '../chrome/browser/storage_monitor/storage_monitor_linux.h',
+        '../chrome/browser/storage_monitor/storage_monitor_mac.h',
+        '../chrome/browser/storage_monitor/storage_monitor_mac.mm',
+        '../chrome/browser/storage_monitor/storage_monitor_win.cc',
+        '../chrome/browser/storage_monitor/storage_monitor_win.h',
+        '../chrome/browser/storage_monitor/transient_device_ids.cc',
+        '../chrome/browser/storage_monitor/transient_device_ids.h',
+        '../chrome/browser/storage_monitor/udev_util_linux.cc',
+        '../chrome/browser/storage_monitor/udev_util_linux.h',
+        '../chrome/browser/storage_monitor/volume_mount_watcher_win.cc',
+        '../chrome/browser/storage_monitor/volume_mount_watcher_win.h',
+      ],
+      'conditions': [
+        ['OS=="linux"', {
+          'dependencies': [
+            '../build/linux/system.gyp:udev',
+            '../dbus/dbus.gyp:dbus',
+            '../device/media_transfer_protocol/media_transfer_protocol.gyp:device_media_transfer_protocol',
+            '../device/media_transfer_protocol/media_transfer_protocol.gyp:mtp_file_entry_proto',
+            '../device/media_transfer_protocol/media_transfer_protocol.gyp:mtp_storage_info_proto',
+          ],
+        }],
+      ],
+    },
+  ],
+}

--- a/components/storage_monitor/removable_storage_observer.h
+++ b/components/storage_monitor/removable_storage_observer.h
@@ -1,0 +1,10 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_STORAGE_MONITOR_REMOVABLE_STORAGE_OBSERVER_H_
+#define COMPONENTS_STORAGE_MONITOR_REMOVABLE_STORAGE_OBSERVER_H_
+
+#include "chrome/browser/storage_monitor/removable_storage_observer.h"
+
+#endif  // COMPONENTS_STORAGE_MONITOR_REMOVABLE_STORAGE_OBSERVER_H_

--- a/components/storage_monitor/storage_monitor.h
+++ b/components/storage_monitor/storage_monitor.h
@@ -1,0 +1,10 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_STORAGE_MONITOR_STORAGE_MONITOR_H_
+#define COMPONENTS_STORAGE_MONITOR_STORAGE_MONITOR_H_
+
+#include "chrome/browser/storage_monitor/storage_monitor.h"
+
+#endif  // COMPONENTS_STORAGE_MONITOR_STORAGE_MONITOR_H_


### PR DESCRIPTION
So we can compile it as a module for Crosswalk and use it as platform
abstraction for the Device Capabilities getStorageInfo() API.

This is being worked upstream at and got a green light to proceed:
https://codereview.chromium.org/152343005/

It probably wont be necessary after next time we bump Chromium.
