### PR TITLE
[Views] Fix compiler initialization order errors.

### DIFF
--- a/ui/views/widget/widget.cc
+++ b/ui/views/widget/widget.cc
@@ -129,8 +129,8 @@ Widget::InitParams::InitParams()
       top_level(false),
       layer_type(aura::WINDOW_LAYER_TEXTURED),
       context(NULL),
-      net_wm_pid(0),
-      force_show_in_taskbar(false) {
+      force_show_in_taskbar(false),
+      net_wm_pid(0) {
 }
 
 Widget::InitParams::InitParams(Type type)
@@ -155,8 +155,8 @@ Widget::InitParams::InitParams(Type type)
       top_level(false),
       layer_type(aura::WINDOW_LAYER_TEXTURED),
       context(NULL),
-      net_wm_pid(0),
-      force_show_in_taskbar(false) {
+      force_show_in_taskbar(false),
+      net_wm_pid(0) {
 }
 
 Widget::InitParams::~InitParams() {


### PR DESCRIPTION
`net_wm_pid` declared after `force_show_in_taskbar`, it should be initialized as same order. 
