### PR TITLE
Enabling Hardware Acceleration with Libva in linux-x86.

### DIFF
--- a/content/common/gpu/media/gpu_video_decode_accelerator.cc
+++ b/content/common/gpu/media/gpu_video_decode_accelerator.cc
@@ -28,7 +28,7 @@
 #elif defined(OS_CHROMEOS) && defined(ARCH_CPU_ARMEL) && defined(USE_X11)
 #include "content/common/gpu/media/v4l2_video_decode_accelerator.h"
 #include "content/common/gpu/media/v4l2_video_device.h"
-#elif defined(OS_CHROMEOS) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
+#elif defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
 #include "content/common/gpu/media/vaapi_video_decode_accelerator.h"
 #include "ui/gl/gl_context_glx.h"
 #include "ui/gl/gl_implementation.h"
@@ -285,7 +285,7 @@ void GpuVideoDecodeAccelerator::Initialize(
                                      make_context_current_,
                                      device.Pass(),
                                      io_message_loop_));
-#elif defined(OS_CHROMEOS) && defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
+#elif defined(ARCH_CPU_X86_FAMILY) && defined(USE_X11)
   if (gfx::GetGLImplementation() != gfx::kGLImplementationDesktopGL) {
     VLOG(1) << "HW video decode acceleration not available without "
                "DesktopGL (GLX).";

--- a/content/common/gpu/media/video_decode_accelerator_unittest.cc
+++ b/content/common/gpu/media/video_decode_accelerator_unittest.cc
@@ -53,7 +53,7 @@
 
 #if defined(OS_WIN)
 #include "content/common/gpu/media/dxva_video_decode_accelerator.h"
-#elif defined(OS_CHROMEOS)
+#elif defined(OS_CHROMEOS) || defined(OS_LINUX)
 #if defined(ARCH_CPU_ARMEL)
 #include "content/common/gpu/media/v4l2_video_decode_accelerator.h"
 #include "content/common/gpu/media/v4l2_video_device.h"
@@ -548,7 +548,7 @@ void GLRenderingVDAClient::CreateAndStartDecoder() {
 #if defined(OS_WIN)
   decoder_.reset(
       new DXVAVideoDecodeAccelerator(client, base::Bind(&DoNothingReturnTrue)));
-#elif defined(OS_CHROMEOS)
+#elif defined(OS_CHROMEOS) || defined(OS_LINUX)
 #if defined(ARCH_CPU_ARMEL)
 
   scoped_ptr<V4L2Device> device = V4L2Device::Create();

--- a/content/content_common.gypi
+++ b/content/content_common.gypi
@@ -567,7 +567,7 @@
         ],
       },
     }],
-    ['target_arch != "arm" and chromeos == 1 and use_x11 == 1', {
+    ['target_arch != "arm" and use_x11 == 1', {
       'sources': [
         'common/gpu/media/h264_dpb.cc',
         'common/gpu/media/h264_dpb.h',

--- a/gpu/config/software_rendering_list_json.cc
+++ b/gpu/config/software_rendering_list_json.cc
@@ -521,12 +521,17 @@ const char kSoftwareRenderingListJson[] = LONG_STRING_CONST(
     },
     {
       "id": 48,
-      "description": "Accelerated video decode is unavailable on Mac and Linux",
-      "cr_bugs": [137247, 133828],
+      "description": "Accelerated video decode is unavailable on Mac",
+      "cr_bugs": [133828],
       "exceptions": [
         {
           "os": {
             "type": "chromeos"
+          }
+        },
+        {
+          "os": {
+            "type": "linux"
           }
         },
         {


### PR DESCRIPTION
This commit is not upstreamable.

Currently, VAAPI only enabled for ChromeOS and Windows on
upstream. Although the ChromeOS uses same libva API as
common linux world, upstream refuesed to enable it for linux
common with maintainence concern. Refer to
"https://codereview.chromium.org/16430003/" for more details.

Upstream confirm VAVDA will continue to be restricted to
CrOS/X86 for dev & testing only and not for chromium road map.
So we maintain it for Crosswalk and that will benifit
linux with VAAPI installed and includes Tizen.
