### PR TITLE
[Temp] Backport Chromium r249361.

### DIFF
--- a/media/audio/pulse/audio_manager_pulse.cc
+++ b/media/audio/pulse/audio_manager_pulse.cc
@@ -10,7 +10,9 @@
 #include "base/logging.h"
 #include "base/nix/xdg_util.h"
 #include "base/stl_util.h"
+#if defined(USE_ALSA)
 #include "media/audio/alsa/audio_manager_alsa.h"
+#endif
 #include "media/audio/audio_parameters.h"
 #include "media/audio/pulse/pulse_input.h"
 #include "media/audio/pulse/pulse_output.h"
@@ -78,7 +80,9 @@ bool AudioManagerPulse::HasAudioInputDevices() {
 }
 
 void AudioManagerPulse::ShowAudioInputSettings() {
+#if defined(USE_ALSA)
   AudioManagerAlsa::ShowLinuxAudioInputSettings();
+#endif
 }
 
 void AudioManagerPulse::GetAudioDeviceNames(


### PR DESCRIPTION
Original author: joone.hur@intel.com

From the original commit message:

  Build fix when use_alsa=0.

  When use_alsa=0, there is a link error as follows:

  ../../media/audio/pulse/audio_manager_pulse.cc:81: error: undefined
reference to 'media::AudioManagerAlsa::ShowLinuxAudioInputSettings()'
 collect2: error: ld returned 1 exit status
 ninja: build stopped: subcommand failed.

  This patch allows to add a guard to alsa related code to fix this link
error.

  BUG=none

  Review URL: https://codereview.chromium.org/150573017

This commit is necessary while we disable Alsa support in Tizen; which is 
necessary until TIVI-2685 doesn't make it into all Tizen profiles.
