### PR TITLE
[Android] Turn on WebNotification runtime feature on Android

### DIFF
--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -35,8 +35,8 @@ static void SetRuntimeFeatureDefaultsForPlatform() {
   WebRuntimeFeatures::enableGamepad(false);
   // Android does not have support for PagePopup
   WebRuntimeFeatures::enablePagePopup(false);
-  // Android does not yet support the Web Notification API. crbug.com/115320
-  WebRuntimeFeatures::enableNotifications(false);
+  // Crosswalk supports the Web Notification API on Android.
+  WebRuntimeFeatures::enableNotifications(true);
   // Android does not yet support SharedWorker. crbug.com/154571
   WebRuntimeFeatures::enableSharedWorker(false);
   // Android does not yet support NavigatorContentUtils.


### PR DESCRIPTION
It's disabled for chrome on Android.
For crosswalk, it will have an implementation working with
Android Notification.

BUG=https://crosswalk-project.org/jira/browse/XWALK-94
