### PR TITLE
[Android] Volume is too low when playing audio through WebAudio API

### DIFF
--- a/media/audio/android/audio_manager_android.h
+++ b/media/audio/android/audio_manager_android.h
@@ -67,6 +67,7 @@ class MEDIA_EXPORT AudioManagerAndroid : public AudioManagerBase {
       const AudioParameters& input_params) OVERRIDE;
 
  private:
+  bool HasNoAudioInputStreams();
   void SetAudioMode(int mode);
   void RegisterHeadsetReceiver();
   void UnregisterHeadsetReceiver();
@@ -89,6 +90,10 @@ class MEDIA_EXPORT AudioManagerAndroid : public AudioManagerBase {
   // AudioManager::MakeAudioOutputStream on the audio thread. For now, this
   // lock is used to guard access to |streams_|.
   base::Lock streams_lock_;
+
+  // Enabled when first input stream is created and set to false when last
+  // input stream is destroyed. Also affects the stream type of output streams.
+  bool communication_mode_is_on_;
 
   DISALLOW_COPY_AND_ASSIGN(AudioManagerAndroid);
 };

--- a/media/audio/android/opensles_output.cc
+++ b/media/audio/android/opensles_output.cc
@@ -20,8 +20,10 @@
 namespace media {
 
 OpenSLESOutputStream::OpenSLESOutputStream(AudioManagerAndroid* manager,
-                                           const AudioParameters& params)
+                                           const AudioParameters& params,
+                                           SLint32 stream_type)
     : audio_manager_(manager),
+      stream_type_(stream_type),
       callback_(NULL),
       player_(NULL),
       simple_buffer_queue_(NULL),
@@ -30,7 +32,8 @@ OpenSLESOutputStream::OpenSLESOutputStream(AudioManagerAndroid* manager,
       started_(false),
       muted_(false),
       volume_(1.0) {
-  DVLOG(2) << "OpenSLESOutputStream::OpenSLESOutputStream()";
+  DVLOG(2) << "OpenSLESOutputStream::OpenSLESOutputStream("
+           << "stream_type=" << stream_type << ")";
   format_.formatType = SL_DATAFORMAT_PCM;
   format_.numChannels = static_cast<SLuint32>(params.channels());
   // Provides sampling rate in milliHertz to OpenSLES.
@@ -247,11 +250,11 @@ bool OpenSLESOutputStream::CreatePlayer() {
           player_object_.Get(), SL_IID_ANDROIDCONFIGURATION, &player_config),
       false);
 
-  SLint32 stream_type = SL_ANDROID_STREAM_VOICE;
+  // Set configuration using the stream type provided at construction.
   LOG_ON_FAILURE_AND_RETURN(
       (*player_config)->SetConfiguration(player_config,
                                          SL_ANDROID_KEY_STREAM_TYPE,
-                                         &stream_type,
+                                         &stream_type_,
                                          sizeof(SLint32)),
       false);
 

--- a/media/audio/android/opensles_output.h
+++ b/media/audio/android/opensles_output.h
@@ -28,7 +28,8 @@ class OpenSLESOutputStream : public AudioOutputStream {
   static const int kMaxNumOfBuffersInQueue = 2;
 
   OpenSLESOutputStream(AudioManagerAndroid* manager,
-                       const AudioParameters& params);
+                       const AudioParameters& params,
+                       SLint32 stream_type);
 
   virtual ~OpenSLESOutputStream();
 
@@ -76,6 +77,10 @@ class OpenSLESOutputStream : public AudioOutputStream {
   base::Lock lock_;
 
   AudioManagerAndroid* audio_manager_;
+
+  // Audio playback stream type.
+  // See SLES/OpenSLES_Android.h for details.
+  SLint32 stream_type_;
 
   AudioSourceCallback* callback_;
 


### PR DESCRIPTION
This patch is back ported from chromium trunk, since the too low sound in webaudio
brings a bad user experience, and gets so many compaints from web game developers.

Today, WebAudio uses the OpenSL ES low-latency audio backend in media/audio,
but the stream type is always communication mode (which is OK for WebRTC but
not for WebAudio).

This patch ensures that:
- Only switch to system-wide Communication mode when a low-latency input stream
  is created (e.g. from getUserMedia).
- Opens the native output stream in Media mode if system mode is Media and in
  Communication mode if system mode is Communication.

TEST=http://chromium.googlecode.com/svn/trunk/samples/audio/shiny-drum-machine.html

BUG=https://crosswalk-project.org/jira/browse/XWALK-980
