### PR TITLE
[Tizen] Enable geolocation for Tizen

### DIFF
--- a/content/browser/geolocation/location_arbitrator_impl.cc
+++ b/content/browser/geolocation/location_arbitrator_impl.cc
@@ -150,7 +150,7 @@ LocationProvider* LocationArbitratorImpl::NewNetworkLocationProvider(
     net::URLRequestContextGetter* context,
     const GURL& url,
     const base::string16& access_token) {
-#if defined(OS_ANDROID) || defined(OS_TIZEN_MOBILE)
+#if defined(OS_ANDROID) || defined(OS_TIZEN)
   // Android uses its own SystemLocationProvider.
   return NULL;
 #else
@@ -160,7 +160,7 @@ LocationProvider* LocationArbitratorImpl::NewNetworkLocationProvider(
 }
 
 LocationProvider* LocationArbitratorImpl::NewSystemLocationProvider() {
-#if defined(OS_TIZEN_MOBILE)
+#if defined(OS_TIZEN)
   return content::NewSystemLocationProvider();
 #elif defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
   return NULL;


### PR DESCRIPTION
Currently, geolocation is enabled only for Tizen mobile profile.
This patch enables geolocation subsystem for Tizen IVI as well.
