### PR TITLE
Backport Chromium changes: revision 251981

### DIFF
--- a/build/linux/system.gyp
+++ b/build/linux/system.gyp
@@ -107,6 +107,255 @@
         },
       ],  # targets
     }],
+    [ 'use_x11==1', {
+      # Hide X11 and related dependencies when use_x11=0
+      'targets': [
+        {
+          'target_name': 'x11',
+          'type': 'none',
+          'toolsets': ['host', 'target'],
+          'conditions': [
+            ['_toolset=="target"', {
+              'direct_dependent_settings': {
+                'cflags': [
+                  '<!@(<(pkg-config) --cflags x11)',
+                ],
+              },
+              'link_settings': {
+                'ldflags': [
+                  '<!@(<(pkg-config) --libs-only-L --libs-only-other x11 xi)',
+                ],
+                'libraries': [
+                  '<!@(<(pkg-config) --libs-only-l x11 xi)',
+                ],
+              },
+            }, {
+              'direct_dependent_settings': {
+                'cflags': [
+                  '<!@(pkg-config --cflags x11)',
+                ],
+              },
+              'link_settings': {
+                'ldflags': [
+                  '<!@(pkg-config --libs-only-L --libs-only-other x11 xi)',
+                ],
+                'libraries': [
+                  '<!@(pkg-config --libs-only-l x11 xi)',
+                ],
+              },
+            }],
+          ],
+        },
+        {
+          'target_name': 'xcursor',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(<(pkg-config) --cflags xcursor)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(<(pkg-config) --libs-only-L --libs-only-other xcursor)',
+            ],
+            'libraries': [
+              '<!@(<(pkg-config) --libs-only-l xcursor)',
+            ],
+          },
+        },
+        {
+          'target_name': 'xcomposite',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(<(pkg-config) --cflags xcomposite)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(<(pkg-config) --libs-only-L --libs-only-other xcomposite)',
+            ],
+            'libraries': [
+              '<!@(<(pkg-config) --libs-only-l xcomposite)',
+            ],
+          },
+        },
+        {
+          'target_name': 'xdamage',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(<(pkg-config) --cflags xdamage)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(<(pkg-config) --libs-only-L --libs-only-other xdamage)',
+            ],
+            'libraries': [
+              '<!@(<(pkg-config) --libs-only-l xdamage)',
+            ],
+          },
+        },
+        {
+          'target_name': 'xext',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(<(pkg-config) --cflags xext)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(<(pkg-config) --libs-only-L --libs-only-other xext)',
+            ],
+            'libraries': [
+              '<!@(<(pkg-config) --libs-only-l xext)',
+            ],
+          },
+        },
+        {
+          'target_name': 'xfixes',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(<(pkg-config) --cflags xfixes)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(<(pkg-config) --libs-only-L --libs-only-other xfixes)',
+            ],
+            'libraries': [
+              '<!@(<(pkg-config) --libs-only-l xfixes)',
+            ],
+          },
+        },
+        {
+          'target_name': 'xi',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(<(pkg-config) --cflags xi)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(<(pkg-config) --libs-only-L --libs-only-other xi)',
+            ],
+            'libraries': [
+              '<!@(<(pkg-config) --libs-only-l xi)',
+            ],
+          },
+        },
+        {
+          'target_name': 'xrandr',
+          'type': 'none',
+          'toolsets': ['host', 'target'],
+          'conditions': [
+            ['_toolset=="target"', {
+              'direct_dependent_settings': {
+                'cflags': [
+                  '<!@(<(pkg-config) --cflags xrandr)',
+                ],
+              },
+              'link_settings': {
+                'ldflags': [
+                  '<!@(<(pkg-config) --libs-only-L --libs-only-other xrandr)',
+                ],
+                'libraries': [
+                  '<!@(<(pkg-config) --libs-only-l xrandr)',
+                ],
+              },
+            }, {
+              'direct_dependent_settings': {
+                'cflags': [
+                  '<!@(pkg-config --cflags xrandr)',
+                ],
+              },
+              'link_settings': {
+                'ldflags': [
+                  '<!@(pkg-config --libs-only-L --libs-only-other xrandr)',
+                ],
+                'libraries': [
+                  '<!@(pkg-config --libs-only-l xrandr)',
+                ],
+              },
+            }],
+          ],
+        },
+        {
+          'target_name': 'xrender',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(<(pkg-config) --cflags xrender)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(<(pkg-config) --libs-only-L --libs-only-other xrender)',
+            ],
+            'libraries': [
+              '<!@(<(pkg-config) --libs-only-l xrender)',
+            ],
+          },
+        },
+        {
+          'target_name': 'xscrnsaver',
+          'type': 'none',
+          'direct_dependent_settings': {
+            'cflags': [
+              '<!@(<(pkg-config) --cflags xscrnsaver)',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '<!@(<(pkg-config) --libs-only-L --libs-only-other xscrnsaver)',
+            ],
+            'libraries': [
+              '<!@(<(pkg-config) --libs-only-l xscrnsaver)',
+            ],
+          },
+        },
+        {
+          'target_name': 'xtst',
+          'type': 'none',
+          'toolsets': ['host', 'target'],
+          'conditions': [
+            ['_toolset=="target"', {
+              'direct_dependent_settings': {
+                'cflags': [
+                  '<!@(<(pkg-config) --cflags xtst)',
+                ],
+              },
+              'link_settings': {
+                'ldflags': [
+                  '<!@(<(pkg-config) --libs-only-L --libs-only-other xtst)',
+                ],
+                'libraries': [
+                  '<!@(<(pkg-config) --libs-only-l xtst)',
+                ],
+              },
+            }, {
+              'direct_dependent_settings': {
+                'cflags': [
+                  '<!@(pkg-config --cflags xtst)',
+                ],
+              },
+              'link_settings': {
+                'ldflags': [
+                  '<!@(pkg-config --libs-only-L --libs-only-other xtst)',
+                ],
+                'libraries': [
+                  '<!@(pkg-config --libs-only-l xtst)',
+                ],
+              },
+            }]
+          ]
+        }
+      ],  # targets
+    }],
   ],  # conditions
   'targets': [
     {
@@ -755,120 +1004,6 @@
             ],
             'libraries': [
               '<!@(<(pkg-config) --libs-only-l libudev)',
-            ],
-          },
-        }],
-      ],
-    },
-    {
-      'target_name': 'x11',
-      'type': 'none',
-      'toolsets': ['host', 'target'],
-      'conditions': [
-        ['_toolset=="target"', {
-          'direct_dependent_settings': {
-            'cflags': [
-              '<!@(<(pkg-config) --cflags x11)',
-            ],
-          },
-          'link_settings': {
-            'ldflags': [
-              '<!@(<(pkg-config) --libs-only-L --libs-only-other x11 xi)',
-            ],
-            'libraries': [
-              '<!@(<(pkg-config) --libs-only-l x11 xi)',
-            ],
-          },
-        }, {
-          'direct_dependent_settings': {
-            'cflags': [
-              '<!@(pkg-config --cflags x11)',
-            ],
-          },
-          'link_settings': {
-            'ldflags': [
-              '<!@(pkg-config --libs-only-L --libs-only-other x11 xi)',
-            ],
-            'libraries': [
-              '<!@(pkg-config --libs-only-l x11 xi)',
-            ],
-          },
-        }],
-      ],
-    },
-    {
-      'target_name': 'xext',
-      'type': 'none',
-      'conditions': [
-        ['_toolset=="target"', {
-          'direct_dependent_settings': {
-            'cflags': [
-              '<!@(<(pkg-config) --cflags xext)',
-            ],
-          },
-          'link_settings': {
-            'ldflags': [
-              '<!@(<(pkg-config) --libs-only-L --libs-only-other xext)',
-            ],
-            'libraries': [
-              '<!@(<(pkg-config) --libs-only-l xext)',
-            ],
-          },
-        }],
-      ],
-    },
-    {
-      'target_name': 'xfixes',
-      'type': 'none',
-      'conditions': [
-        ['_toolset=="target"', {
-          'direct_dependent_settings': {
-            'cflags': [
-              '<!@(<(pkg-config) --cflags xfixes)',
-            ],
-          },
-          'link_settings': {
-            'ldflags': [
-              '<!@(<(pkg-config) --libs-only-L --libs-only-other xfixes)',
-            ],
-            'libraries': [
-              '<!@(<(pkg-config) --libs-only-l xfixes)',
-            ],
-          },
-        }],
-      ],
-    },
-    {
-      'target_name': 'xrandr',
-      'type': 'none',
-      'toolsets': ['host', 'target'],
-      'conditions': [
-        ['_toolset=="target"', {
-          'direct_dependent_settings': {
-            'cflags': [
-              '<!@(<(pkg-config) --cflags xrandr)',
-            ],
-          },
-          'link_settings': {
-            'ldflags': [
-              '<!@(<(pkg-config) --libs-only-L --libs-only-other xrandr)',
-            ],
-            'libraries': [
-              '<!@(<(pkg-config) --libs-only-l xrandr)',
-            ],
-          },
-        }, {
-          'direct_dependent_settings': {
-            'cflags': [
-              '<!@(pkg-config --cflags xrandr)',
-            ],
-          },
-          'link_settings': {
-            'ldflags': [
-              '<!@(pkg-config --libs-only-L --libs-only-other xrandr)',
-            ],
-            'libraries': [
-              '<!@(pkg-config --libs-only-l xrandr)',
             ],
           },
         }],

--- a/chrome/chrome_browser.gypi
+++ b/chrome/chrome_browser.gypi
@@ -3457,7 +3457,6 @@
               'dependencies': [
                 '../build/linux/system.gyp:dbus',
                 '../build/linux/system.gyp:fontconfig',
-                '../build/linux/system.gyp:x11',
                 '../dbus/dbus.gyp:dbus',
               ],
               'sources/': [
@@ -3468,6 +3467,12 @@
             ['toolkit_uses_gtk==1', {
               'sources/': [
                 ['exclude', '^browser/lifetime/application_lifetime_stub.cc'],
+              ],
+            }],
+            # x11 build
+            ['use_x11==1', {
+              'dependencies': [
+                '../build/linux/system.gyp:x11',
               ],
             }],
           ],

--- a/chrome/chrome_browser_extensions.gypi
+++ b/chrome/chrome_browser_extensions.gypi
@@ -1027,12 +1027,21 @@
             '../ui/keyboard/keyboard.gyp:keyboard_resources',
           ],
         }],
-        ['OS=="linux" and use_aura==1', {
-          'dependencies': [
-            '../build/linux/system.gyp:dbus',
-            '../build/linux/system.gyp:fontconfig',
-            '../build/linux/system.gyp:x11',
-            '../dbus/dbus.gyp:dbus',
+        ['OS=="linux"', {
+          'conditions': [
+            ['use_aura==1', {
+              'dependencies': [
+                '../build/linux/system.gyp:dbus',
+                '../build/linux/system.gyp:fontconfig',
+                '../dbus/dbus.gyp:dbus',
+              ],
+            }],
+            # x11 build
+            ['use_x11==1', {
+              'dependencies': [
+                '../build/linux/system.gyp:x11',
+              ],
+            }],
           ],
         }],
         ['safe_browsing==1', {

--- a/chrome/chrome_browser_ui.gypi
+++ b/chrome/chrome_browser_ui.gypi
@@ -3302,7 +3302,6 @@
               'dependencies': [
                 '../build/linux/system.gyp:dbus',
                 '../build/linux/system.gyp:fontconfig',
-                '../build/linux/system.gyp:x11',
                 '../dbus/dbus.gyp:dbus',
               ],
             }],
@@ -3311,6 +3310,12 @@
               'sources/': [
                 ['exclude', '^browser/ui/toolbar/bookmark_sub_menu_model.cc'],
                 ['exclude', '^browser/ui/views/notifications/balloon_collection_views.cc'],
+              ],
+            }],
+            # x11 build
+            ['use_x11==1', {
+              'dependencies': [
+                '../build/linux/system.gyp:x11',
               ],
             }],
           ],

--- a/chrome/chrome_exe.gypi
+++ b/chrome/chrome_exe.gypi
@@ -201,11 +201,16 @@
                 '<@(chromium_child_dependencies)',
                 '../content/content.gyp:content_app_both',
                 # Needed for chrome_main.cc initialization of libraries.
-                '../build/linux/system.gyp:x11',
                 '../build/linux/system.gyp:pangocairo',
-                '../build/linux/system.gyp:xext',
                 # Needed to use the master_preferences functions
                 'installer_util',
+              ],
+            }],
+            # x11 build. Needed for chrome_main.cc initialization of libraries.
+            ['use_x11==1', {
+              'dependencies': [
+                '../build/linux/system.gyp:x11',
+                '../build/linux/system.gyp:xext',
               ],
             }],
           ],

--- a/gpu/tools/tools.gyp
+++ b/gpu/tools/tools.gyp
@@ -9,7 +9,7 @@
   'targets': [
   ],
   'conditions': [
-    ['OS == "linux" and target_arch != "arm"', {
+    ['OS == "linux" and target_arch != "arm" and use_x11==1', {
       'targets': [
         {
           'target_name': 'compositor_model_bench',

--- a/media/cast/cast.gyp
+++ b/media/cast/cast.gyp
@@ -148,7 +148,11 @@
             '<(DEPTH)/media/cast/test/receiver.cc',
           ],
           'conditions': [
-            ['OS == "linux"', {
+            ['OS == "linux and use_x11==1"', {
+              'dependencies': [
+                '<(DEPTH)/build/linux/system.gyp:x11',
+                '<(DEPTH)/build/linux/system.gyp:xext',
+              ],
               'sources': [
                 '<(DEPTH)/media/cast/test/linux_output_window.cc',
                 '<(DEPTH)/media/cast/test/linux_output_window.h',

--- a/tools/android/forwarder2/forwarder.gyp
+++ b/tools/android/forwarder2/forwarder.gyp
@@ -62,7 +62,6 @@
       'toolsets': ['host'],
       'dependencies': [
         '../../../base/base.gyp:base',
-        '../../../build/linux/system.gyp:x11',
         '../common/common.gyp:android_tools_common',
       ],
       'include_dirs': [
@@ -78,8 +77,8 @@
         'host_forwarder_main.cc',
         'pipe_notifier.cc',
         'socket.cc',
-        # TODO(pliard): Remove this and x11 dependency above. This is needed
-        # to avoid undefined references at link time.
+        # TODO(pliard): Remove this. This is needed to avoid undefined
+        # references at link time.
         '../../../base/message_loop/message_pump_glib.cc',
         '../../../base/message_loop/message_pump_gtk.cc',
       ],


### PR DESCRIPTION
https://src.chromium.org/viewvc/chrome?revision=251981&view=revision

Hide X11 dependencies when use_x11=0.

When using a non X11 build with Ozone, we still have dependencies on
X11. This patch tries to hide X11 and related dependencies when
use_x11=0

Review URL: https://codereview.chromium.org/148643002

Signed-off-by: Baptiste DURAND baptiste.durand@open.eurogiciel.org
