### PR TITLE
.gitignore: Ignore ozone/.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ v8.log
 /net/testserver.log
 /out
 /out_*
+/ozone
 /pdf
 /ppapi/native_client/nacl_irt.xml
 /ppapi/native_client/ppapi_lib.xml


### PR DESCRIPTION
Just like we did for .xwalk/, ignore the ozone/ directory (it also prevents it
from being deleted if one runs gclient sync with -D).
