### PR TITLE
[Android] Allow intercepter to extract paks

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/ResourceExtractor.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ResourceExtractor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
@@ -38,11 +39,17 @@ public class ResourceExtractor {
     private static final String PAK_FILENAMES = "Pak filenames";
 
     private static String[] sMandatoryPaks = null;
+    private static ResourceIntercepter sIntercepter = null;
 
     // By default, we attempt to extract a pak file for the users
     // current device locale. Use setExtractImplicitLocale() to
     // change this behavior.
     private static boolean sExtractImplicitLocalePak = true;
+
+    public interface ResourceIntercepter {
+        Set<String> getInterceptableResourceList();
+        InputStream interceptLoadingForResource(String resource);
+    }
 
     private class ExtractTask extends AsyncTask<Void, Void, Void> {
         private static final int BUFFER_SIZE = 16 * 1024;
@@ -106,6 +113,18 @@ public class ResourceExtractor {
                 // created above.
                 byte[] buffer = null;
                 String[] files = manager.list("");
+                if (sIntercepter != null) {
+                    Set<String> filesIncludingInterceptableFiles =
+                            sIntercepter.getInterceptableResourceList();
+                    if (filesIncludingInterceptableFiles != null &&
+                            !filesIncludingInterceptableFiles.isEmpty()) {
+                        for (String file : files) {
+                            filesIncludingInterceptableFiles.add(file);
+                        }
+                        files = new String[filesIncludingInterceptableFiles.size()];
+                        filesIncludingInterceptableFiles.toArray(files);
+                    }
+                }
                 for (String file : files) {
                     if (!paksToInstall.matcher(file).matches()) {
                         continue;
@@ -118,7 +137,10 @@ public class ResourceExtractor {
                     InputStream is = null;
                     OutputStream os = null;
                     try {
-                        is = manager.open(file);
+                        if (sIntercepter != null) {
+                            is = sIntercepter.interceptLoadingForResource(file);
+                        }
+                        if (is == null) is = manager.open(file);
                         os = new FileOutputStream(output);
                         Log.i(LOGTAG, "Extracting resource " + file);
                         if (buffer == null) {
@@ -246,6 +268,19 @@ public class ResourceExtractor {
                 : "Must be called before startExtractingResources is called";
         sMandatoryPaks = mandatoryPaks;
 
+    }
+
+    /**
+     * Allow embedders to intercept the resource loading process. Embedders may
+     * want to load paks from res/raw instead of assets, since assets are not
+     * supported in Android library project.
+     * @param intercepter The instance of intercepter which provides the files list
+     * to intercept and the inputstream for the files it wants to intercept with.
+     */
+    public static void setResourceIntercepter(ResourceIntercepter intercepter) {
+        assert (sInstance == null || sInstance.mExtractTask == null)
+                : "Must be called before startExtractingResources is called";
+        sIntercepter = intercepter;
     }
 
     /**


### PR DESCRIPTION
Embedders may want to put paks in res/raw instead of assets.
Because for Android Library project, assets is not handled well.
Add intercepter in ResourceExtractor to allow embedder to
provide the interceptable resources' list and the inputstream
to intercept with.
