### PR TITLE
Revert "[Android] Enable Web Audio on x86 -- part 3"

### DIFF
--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -11,7 +11,6 @@
 
 #if defined(OS_ANDROID)
 #include <cpu-features.h>
-#include "base/android/build_info.h"
 #include "media/base/android/media_codec_bridge.h"
 #endif
 
@@ -30,7 +29,8 @@ static void SetRuntimeFeatureDefaultsForPlatform() {
   // WebAudio is enabled by default only on ARM and only when the
   // MediaCodec API is available.
   WebRuntimeFeatures::enableWebAudio(
-    media::MediaCodecBridge::IsAvailable());
+      media::MediaCodecBridge::IsAvailable() &&
+      (android_getCpuFamily() == ANDROID_CPU_FAMILY_ARM));
   // Android does not support the Gamepad API.
   WebRuntimeFeatures::enableGamepad(false);
   // Android does not have support for PagePopup


### PR DESCRIPTION
This reverts commit af75b1265672e5de08f381f6ea923c7075caa522.

The patch is useless after rebasing, as we have already enabled
Web Audio on x86 via the command line in xwalk.
See https://github.com/crosswalk-project/crosswalk/pull/1643
