### PR TITLE
[Backport] Cherry-pick r253775 (b84054f) from upstream.

### DIFF
--- a/ui/base/cursor/cursor_loader_ozone.cc
+++ b/ui/base/cursor/cursor_loader_ozone.cc
@@ -64,11 +64,9 @@ void CursorLoaderOzone::SetPlatformCursor(gfx::NativeCursor* cursor) {
     // TODO(dnicoara) Add support for custom cursors: crbug.com/343155
     cursor->SetPlatformCursor(cursor->platform());
   } else {
-    const gfx::ImageSkiaRep& image_rep =
-        cursors_[kCursorPointer]->GetRepresentation(
-            display().device_scale_factor());
-
-    cursor->SetPlatformCursor(&image_rep.sk_bitmap());
+    // We load different set of cursors with Ash and DesktopAura. Since we do
+    // not have the resource for this cursor, set platform cursor to NULL.
+    cursor->SetPlatformCursor(NULL);
   }
 }
 


### PR DESCRIPTION
Author:    kalyan.kondapally@intel.com kalyan.kondapally@intel.com

  Fix potential crash in CursorLoaderOzone.

  We load a different set of cursors with Ash and DesktopAura. Hence,
  we cannot assume kCursorPointer is always loaded. Instead of making
  any assumptions for default cursor image, we set this as NULL.

  Review URL: https://codereview.chromium.org/179903006

This is required for any Crosswalk target that uses Wayland not to crash 
instantly when the cursor is moved.
