### PR TITLE
[Backport] Remove X11 and GTK dependencies from host_forwarder

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -240,6 +240,7 @@ _BANNED_CPP_FUNCTIONS = (
 _VALID_OS_MACROS = (
     # Please keep sorted.
     'OS_ANDROID',
+    'OS_ANDROID_HOST',
     'OS_BSD',
     'OS_CAT',       # For testing.
     'OS_CHROMEOS',

--- a/base/base.gyp
+++ b/base/base.gyp
@@ -105,19 +105,6 @@
           # hence the *_android.cc files are included but the actual code
           # doesn't have OS_ANDROID / ANDROID defined.
           'conditions': [
-            # Host build on linux depends on system.gyp::gtk as
-            # default linux build has TOOLKIT_GTK defined.
-            ['host_os == "linux"', {
-              'sources/': [
-                ['include', '^atomicops_internals_x86_gcc\\.cc$'],
-              ],
-              'dependencies': [
-                '../build/linux/system.gyp:gtk',
-              ],
-              'export_dependent_settings': [
-                '../build/linux/system.gyp:gtk',
-              ],
-            }],
             ['host_os == "mac"', {
               'sources/': [
                 ['exclude', '^native_library_linux\\.cc$'],

--- a/base/base.gypi
+++ b/base/base.gypi
@@ -811,8 +811,12 @@
             ],
           }],
           ['OS == "android" and _toolset == "host" and host_os == "linux"', {
+            'defines': [
+              'OS_ANDROID_HOST=Linux',
+            ],
             'sources/': [
               # Pull in specific files for host builds.
+              ['include', '^atomicops_internals_x86_gcc\\.cc$'],
               ['include', '^threading/platform_thread_linux\\.cc$'],
             ],
           }],

--- a/base/message_loop/message_loop.h
+++ b/base/message_loop/message_loop.h
@@ -38,7 +38,7 @@
 #include "base/message_loop/message_pump_x11.h"
 #elif defined(USE_OZONE) && !defined(OS_NACL)
 #include "base/message_loop/message_pump_ozone.h"
-#else
+#elif !defined(OS_ANDROID_HOST)
 #define USE_GTK_MESSAGE_PUMP
 #include "base/message_loop/message_pump_gtk.h"
 #if defined(TOOLKIT_GTK)
@@ -57,6 +57,8 @@ class RunLoop;
 class ThreadTaskRunnerHandle;
 #if defined(OS_ANDROID)
 class MessagePumpForUI;
+#elif defined(OS_ANDROID_HOST)
+typedef MessagePumpLibevent MessagePumpForUI;
 #endif
 class WaitableEvent;
 

--- a/tools/android/forwarder2/forwarder.gyp
+++ b/tools/android/forwarder2/forwarder.gyp
@@ -77,10 +77,6 @@
         'host_forwarder_main.cc',
         'pipe_notifier.cc',
         'socket.cc',
-        # TODO(pliard): Remove this. This is needed to avoid undefined
-        # references at link time.
-        '../../../base/message_loop/message_pump_glib.cc',
-        '../../../base/message_loop/message_pump_gtk.cc',
       ],
     },
   ],


### PR DESCRIPTION
Use libevent as the implementation of MessagePumpForUI.

BUG=346113

Review URL: https://codereview.chromium.org/176713005

git-svn-id: svn://svn.chromium.org/chrome/trunk/src@257853 0039d316-1c4b-4281-b951-d872f2087c98
