### PR TITLE
[Tizen IVI] Make HTML5 full screen API work on IVI.

### DIFF
--- a/ui/views/views_delegate.cc
+++ b/ui/views/views_delegate.cc
@@ -9,7 +9,8 @@
 namespace views {
 
 ViewsDelegate::ViewsDelegate()
-    : views_tsc_factory_(new views::ViewsTouchSelectionControllerFactory) {
+    : views_tsc_factory_(new views::ViewsTouchSelectionControllerFactory),
+  should_show_titlebar_(true) {
   ui::TouchSelectionControllerFactory::SetInstance(views_tsc_factory_.get());
 }
 

--- a/ui/views/views_delegate.h
+++ b/ui/views/views_delegate.h
@@ -125,8 +125,15 @@ class VIEWS_EXPORT ViewsDelegate {
   // maximized windows; otherwise to restored windows.
   virtual bool WindowManagerProvidesTitleBar(bool maximized);
 
+  virtual void SetShouldShowTitleBar(bool show_title_bar) {
+    should_show_titlebar_ = show_title_bar;
+  }
+  virtual bool ShouldShowTitleBar() const { return  should_show_titlebar_; }
+
  private:
   scoped_ptr<ViewsTouchSelectionControllerFactory> views_tsc_factory_;
+  // Set to ture if the window should have the title bar.
+  bool should_show_titlebar_;
 };
 
 }  // namespace views

--- a/ui/views/window/custom_frame_view.cc
+++ b/ui/views/window/custom_frame_view.cc
@@ -330,8 +330,9 @@ gfx::Rect CustomFrameView::IconBounds() const {
 
 bool CustomFrameView::ShouldShowTitleBarAndBorder() const {
   if (ViewsDelegate::views_delegate) {
-    return !ViewsDelegate::views_delegate->WindowManagerProvidesTitleBar(
-                frame_->IsMaximized());
+    return ViewsDelegate::views_delegate->ShouldShowTitleBar() &&
+        !ViewsDelegate::views_delegate->WindowManagerProvidesTitleBar(
+        frame_->IsMaximized());
   }
 
   return true;


### PR DESCRIPTION
Currently, Crosswalk for Ozone-wayland shows the title bar by default on IVI.
As a result, when webapps enter fullscreen mode using HTML5 fullscreen API,
their title bar still exist.

This patch allows to hide the title bar in fullscreen mode.

BUG=XWALK-896
