### PR TITLE
[TIZEN] Tag the audio stream as "browser" in pulseaudio.

### DIFF
--- a/media/audio/pulse/pulse.sigs
+++ b/media/audio/pulse/pulse.sigs
@@ -50,3 +50,8 @@ void pa_stream_unref(pa_stream* s);
 int pa_context_errno(pa_context *c);
 const char* pa_strerror(int error);
 pa_cvolume* pa_cvolume_set(pa_cvolume* a, unsigned  channels, pa_volume_t v);
+# Functions from pulse used in TIZEN to tag the audio stream as "browser".
+pa_proplist* pa_proplist_new(void);
+void pa_proplist_free(pa_proplist* p);
+int pa_proplist_sets(pa_proplist *p, const char *key, const char *value);
+pa_stream* pa_stream_new_with_proplist(pa_context* c, const char* name, const pa_sample_spec* ss, const pa_channel_map* map, pa_proplist* proplist);

--- a/media/audio/pulse/pulse_util.cc
+++ b/media/audio/pulse/pulse_util.cc
@@ -261,7 +261,16 @@ bool CreateOutputStream(pa_threaded_mainloop** mainloop,
     // than the default channel map (NULL).
     map = &source_channel_map;
   }
+#if defined(OS_TIZEN)
+  pa_proplist* proplist = pa_proplist_new();
+  pa_proplist_sets(proplist, PA_PROP_MEDIA_ROLE, "browser");
+  *stream = pa_stream_new_with_proplist(*context, "Playback",
+                                        &sample_specifications,
+                                        map, proplist);
+  pa_proplist_free(proplist);
+#else
   *stream = pa_stream_new(*context, "Playback", &sample_specifications, map);
+#endif
   RETURN_ON_FAILURE(*stream, "failed to create PA playback stream");
 
   pa_stream_set_state_callback(*stream, stream_callback, user_data);


### PR DESCRIPTION
Tag the audio stream as "browser" in pulseaudio so that all the streams
coming from the web will be considered by Murphy as coming from the same
source and preempt them for example if there's a phone call coming.

At the moment the full Murphy integration is not in place due to some
integration issues with the main loop. But, once we have all the fixes
in place, we will directly connect to the Murphy's resource engine and
start receiving notifications when any another stream preempting the
streams tagged as 'browser'. This will make the Crosswalk fully
resource-aware.
