### PR TITLE
[Android] Change the API for ApplicationStatus in base dir.

### DIFF
--- a/base/android/java/src/org/chromium/base/ApplicationStatus.java
+++ b/base/android/java/src/org/chromium/base/ApplicationStatus.java
@@ -108,11 +108,11 @@ public class ApplicationStatus {
      *
      * @param application The application whose status you wish to monitor.
      */
-    public static void initialize(BaseChromiumApplication application) {
-        sApplication = application;
+    public static void initialize(Application app) {
+        sApplication = app;
 
-        application.registerWindowFocusChangedListener(
-                new BaseChromiumApplication.WindowFocusChangedListener() {
+        ApplicationStatusManager.registerWindowFocusChangedListener(
+                new ApplicationStatusManager.WindowFocusChangedListener() {
             @Override
             public void onWindowFocusChanged(Activity activity, boolean hasFocus) {
                 if (!hasFocus || activity == sActivity) return;
@@ -127,7 +127,7 @@ public class ApplicationStatus {
             }
         });
 
-        application.registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
+        sApplication.registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
             @Override
             public void onActivityCreated(final Activity activity, Bundle savedInstanceState) {
                 onStateChange(activity, ActivityState.CREATED);

--- a/base/android/java/src/org/chromium/base/ApplicationStatusManager.java
+++ b/base/android/java/src/org/chromium/base/ApplicationStatusManager.java
@@ -1,0 +1,97 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.base;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import android.view.Window;
+
+/**
+ * Basic application functionality that should be shared among all browser applications.
+ */
+public class ApplicationStatusManager {
+    /**
+     * Interface to be implemented by listeners for window focus events.
+     */
+    public interface WindowFocusChangedListener {
+        /**
+         * Called when the window focus changes for {@code activity}.
+         * @param activity The {@link Activity} that has a window focus changed event.
+         * @param hasFocus Whether or not {@code activity} gained or lost focus.
+         */
+        public void onWindowFocusChanged(Activity activity, boolean hasFocus);
+    }
+
+    private static ObserverList<WindowFocusChangedListener> sWindowFocusListeners =
+            new ObserverList<WindowFocusChangedListener>();
+
+    public static void init(Application app) {
+        ApplicationStatus.initialize(app);
+
+        app.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
+            @Override
+            public void onActivityCreated(final Activity activity, Bundle savedInstanceState) {
+                Window.Callback callback = activity.getWindow().getCallback();
+                activity.getWindow().setCallback(new WindowCallbackWrapper(callback) {
+                    @Override
+                    public void onWindowFocusChanged(boolean hasFocus) {
+                        super.onWindowFocusChanged(hasFocus);
+
+                        for (WindowFocusChangedListener listener : sWindowFocusListeners) {
+                            listener.onWindowFocusChanged(activity, hasFocus);
+                        }
+                    }
+                });
+            }
+
+            @Override
+            public void onActivityDestroyed(Activity activity) {
+                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
+            }
+
+            @Override
+            public void onActivityPaused(Activity activity) {
+                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
+            }
+
+            @Override
+            public void onActivityResumed(Activity activity) {
+                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
+            }
+
+            @Override
+            public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
+            }
+
+            @Override
+            public void onActivityStarted(Activity activity) {
+                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
+            }
+
+            @Override
+            public void onActivityStopped(Activity activity) {
+                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
+            }
+        });
+    }
+
+    /**
+     * Registers a listener to receive window focus updates on activities in this application.
+     * @param listener Listener to receive window focus events.
+     */
+    public static void registerWindowFocusChangedListener(WindowFocusChangedListener listener) {
+        sWindowFocusListeners.addObserver(listener);
+    }
+
+    /**
+     * Unregisters a listener from receiving window focus updates on activities in this application.
+     * @param listener Listener that doesn't want to receive window focus events.
+     */
+    public static void unregisterWindowFocusChangedListener(WindowFocusChangedListener listener) {
+        sWindowFocusListeners.removeObserver(listener);
+    }
+}

--- a/base/android/java/src/org/chromium/base/BaseChromiumApplication.java
+++ b/base/android/java/src/org/chromium/base/BaseChromiumApplication.java
@@ -4,96 +4,16 @@
 
 package org.chromium.base;
 
-import android.app.Activity;
 import android.app.Application;
-import android.os.Bundle;
-import android.view.Window;
 
 /**
  * Basic application functionality that should be shared among all browser applications.
  */
 public class BaseChromiumApplication extends Application {
-    /**
-     * Interface to be implemented by listeners for window focus events.
-     */
-    public interface WindowFocusChangedListener {
-        /**
-         * Called when the window focus changes for {@code activity}.
-         * @param activity The {@link Activity} that has a window focus changed event.
-         * @param hasFocus Whether or not {@code activity} gained or lost focus.
-         */
-        public void onWindowFocusChanged(Activity activity, boolean hasFocus);
-    }
-
-    private ObserverList<WindowFocusChangedListener> mWindowFocusListeners =
-            new ObserverList<WindowFocusChangedListener>();
 
     @Override
     public void onCreate() {
         super.onCreate();
-        ApplicationStatus.initialize(this);
-
-        registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
-            @Override
-            public void onActivityCreated(final Activity activity, Bundle savedInstanceState) {
-                Window.Callback callback = activity.getWindow().getCallback();
-                activity.getWindow().setCallback(new WindowCallbackWrapper(callback) {
-                    @Override
-                    public void onWindowFocusChanged(boolean hasFocus) {
-                        super.onWindowFocusChanged(hasFocus);
-
-                        for (WindowFocusChangedListener listener : mWindowFocusListeners) {
-                            listener.onWindowFocusChanged(activity, hasFocus);
-                        }
-                    }
-                });
-            }
-
-            @Override
-            public void onActivityDestroyed(Activity activity) {
-                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
-            }
-
-            @Override
-            public void onActivityPaused(Activity activity) {
-                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
-            }
-
-            @Override
-            public void onActivityResumed(Activity activity) {
-                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
-            }
-
-            @Override
-            public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
-            }
-
-            @Override
-            public void onActivityStarted(Activity activity) {
-                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
-            }
-
-            @Override
-            public void onActivityStopped(Activity activity) {
-                assert activity.getWindow().getCallback() instanceof WindowCallbackWrapper;
-            }
-        });
-    }
-
-    /**
-     * Registers a listener to receive window focus updates on activities in this application.
-     * @param listener Listener to receive window focus events.
-     */
-    public void registerWindowFocusChangedListener(WindowFocusChangedListener listener) {
-        mWindowFocusListeners.addObserver(listener);
-    }
-
-    /**
-     * Unregisters a listener from receiving window focus updates on activities in this application.
-     * @param listener Listener that doesn't want to receive window focus events.
-     */
-    public void unregisterWindowFocusChangedListener(WindowFocusChangedListener listener) {
-        mWindowFocusListeners.removeObserver(listener);
+        ApplicationStatusManager.init(this);
     }
 }


### PR DESCRIPTION
Chromium class inherits from Application directly. This is not suitable
for Crosswalk embedding API. Instead, define a new API which can pass Application
instance as the parameter instead of asking users' application inheriting from
Chromium Application.
