### PR TITLE
[Temp] Add support to provide external ozone files in views.

### DIFF
--- a/ui/views/views.gyp
+++ b/ui/views/views.gyp
@@ -4,6 +4,7 @@
 {
   'variables': {
     'chromium_code': 1,
+    'external_ozone_views_files': [],
   },
   'target_defaults': {
     'conditions': [
@@ -601,6 +602,9 @@
           ],
         }],
         ['use_ozone==1', {
+          'sources': [
+            '<@(external_ozone_views_files)',
+          ],
           'dependencies': [
             '../ozone/ozone.gyp:ozone',
           ],


### PR DESCRIPTION
The original patch comes from the ozone-wayland repository. It is 
patches/0003-Add-support-to-provide-external-ozone-files-in-views.patch.

From the original commit message:

  We have un-necessary dependency on views. This is a temporary patch
 to include desktop_aura/ as part of view target.

One of the most practical results for us is that running a Crosswalk binary 
built with -Dcomponent=shared_library works again.
