### PR TITLE
[Backport] Add base.gyp:base_static as dependency of nacl component

### DIFF
--- a/components/nacl.gyp
+++ b/components/nacl.gyp
@@ -78,6 +78,7 @@
           },
           'dependencies': [
             '../base/base.gyp:base',
+            '../base/base.gyp:base_static',
             '../ipc/ipc.gyp:ipc',
             '../ppapi/native_client/src/trusted/plugin/plugin.gyp:ppGoogleNaClPluginChrome',
             '../ppapi/ppapi_internal.gyp:ppapi_shared',


### PR DESCRIPTION
The switches defined in base_switches.h are used in
nacl_process_host.cc, add dependency is clearly needed for other NaCl
embedder.

This dependency is added in chrome/chrome_common.gypi, thus this issue
is hidden for chrome build.

This is part of an effort to componentize NaCl code.

BUG=244791

Review URL: https://codereview.chromium.org/218763003

git-svn-id: svn://svn.chromium.org/chrome/trunk/src@260856 0039d316-1c4b-4281-b951-d872f2087c98
