### PR TITLE
[Android] Allow extracting resources across APKs

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/ResourceExtractor.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ResourceExtractor.java
@@ -321,6 +321,10 @@ public class ResourceExtractor {
 
         try {
             mExtractTask.get();
+            // ResourceExtractor is not needed any more.
+            // Release static objects to avoid leak of Context.
+            sIntercepter = null;
+            sInstance = null;
         } catch (CancellationException e) {
             // Don't leave the files in an inconsistent state.
             deleteFiles(mContext);


### PR DESCRIPTION
The relevant upstream change is 0f1465d5f, which is:

```
Make the ResourceExtractor use the App context

- Have the resource extractor use/save the application context instead of the activity context.
- It looks like we are currently leaking the main activity here.

BUG=341231

Review URL: https://codereview.chromium.org/204123003

git-svn-id: svn://svn.chromium.org/chrome/trunk/src@258491 0039d316-1c4b-4281-b951-d872f2087c98
```

For xwalk shared mode, the ResourceExtractor needs to read assets via Library Context
and write them to app data via App Context, so it must keep the original Context instead
of getting ApplicationContext of it.
To avoid the activity leaking mentioned in upstream change. The static object in ResourceExtractor
will be released after the background job is done. The ResourceExtractor should not be used
any more from that point.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1384
