### PR TITLE
[Android] Add a new API to register network change broadcast receiver

### DIFF
--- a/net/android/java/src/org/chromium/net/NetworkChangeNotifier.java
+++ b/net/android/java/src/org/chromium/net/NetworkChangeNotifier.java
@@ -116,6 +116,15 @@ public class NetworkChangeNotifier {
         getInstance().setAutoDetectConnectivityStateInternal(shouldAutoDetect);
     }
 
+    /**
+     * If setAutoDetectConnectivityState() called after activity started, it will miss the registration
+     * of connectivity change broadcast receiver.
+     * This function will give the chance to register the broadcast receiver after activity started.
+     */
+    public static void registerNetworkChangeListenerIfNeeded() {
+        getInstance().registerNetworkChangeListenerIfNeededInternal();
+    }
+
     private void destroyAutoDetector() {
         if (mAutoDetector != null) {
             mAutoDetector.destroy();
@@ -138,6 +147,12 @@ public class NetworkChangeNotifier {
             }
         } else {
             destroyAutoDetector();
+        }
+    }
+
+    private void registerNetworkChangeListenerIfNeededInternal() {
+        if (mAutoDetector != null) {
+            mAutoDetector.registerReceiverIfNeeded();
         }
     }
 

--- a/net/android/java/src/org/chromium/net/NetworkChangeNotifierAutoDetect.java
+++ b/net/android/java/src/org/chromium/net/NetworkChangeNotifierAutoDetect.java
@@ -130,6 +130,16 @@ public class NetworkChangeNotifierAutoDetect extends BroadcastReceiver
     }
 
     /**
+     * Give the chance to register the broadcast receiver after activity started.
+     */
+    public void registerReceiverIfNeeded() {
+        if (!mRegistered) {
+            connectionTypeChanged();
+            registerReceiver();
+        }
+    }
+
+    /**
      * Register a BroadcastReceiver in the given context.
      */
     private void registerReceiver() {


### PR DESCRIPTION
The network change broadcast receiver will only be registered when activity state changed.
In XWalk runtime, the XWalkContent will be created after activity started, we need to add a new
API to register the broadcast receiver anytime.

BUG=XWALK-1324
