### PR TITLE
[Android] Ignore status from non tracked activities

### DIFF
--- a/base/android/java/src/org/chromium/base/ApplicationStatus.java
+++ b/base/android/java/src/org/chromium/base/ApplicationStatus.java
@@ -190,6 +190,9 @@ public class ApplicationStatus {
         sCachedApplicationState = null;
 
         ActivityInfo info = sActivityInfo.get(activity);
+        // Ignore status from none tracked activitys.
+        if (info == null) return;
+
         info.setStatus(newState);
 
         // Notify all state observers that are specifically listening to this activity.


### PR DESCRIPTION
When activity_1 start activity_2(contains XWalkView), ApplicationStatus will start tracking when XWalkView initialized, But ApplicationStatus will receive status such as onStop from activity_1, we do not need track activity_1, just ignore it.
For upstream, there is no such kind of case, ApplicationStatus will track all activities inside the package.

BUG=XWALK-1454
