### PR TITLE
[Tizen] Enable media auto play

### DIFF
--- a/content/renderer/web_preferences.cc
+++ b/content/renderer/web_preferences.cc
@@ -323,9 +323,6 @@ void ApplyWebPreferences(const WebPreferences& prefs, WebView* web_view) {
   // Scrollbars should not be stylable.
   settings->setAllowCustomScrollbarInMainFrame(false);
 
-  // Don't auto play music on Tizen devices.
-  settings->setMediaPlaybackRequiresUserGesture(true);
-
   // IME support
   settings->setAutoZoomFocusedNodeToLegibleScale(true);
 


### PR DESCRIPTION
Current setting blocks some media test cases(XWALK-971) and peace keeper.
So, remove this setting and use the default value.
