### PR TITLE
MessagePumpOzone: Compare the same data types in DCHECK_EQ.

### DIFF
--- a/base/message_loop/message_pump_ozone.cc
+++ b/base/message_loop/message_pump_ozone.cc
@@ -45,13 +45,13 @@ MessagePumpOzone* MessagePumpOzone::Current() {
 void MessagePumpOzone::AddDispatcherForRootWindow(
     MessagePumpDispatcher* dispatcher) {
   // Only one root window is supported.
-  DCHECK_EQ(dispatcher_.size(), 0);
+  DCHECK_EQ(dispatcher_.size(), 0U);
   dispatcher_.insert(dispatcher_.begin(), dispatcher);
 }
 
 void MessagePumpOzone::RemoveDispatcherForRootWindow(
       MessagePumpDispatcher* dispatcher) {
-  DCHECK_EQ(dispatcher_.size(), 1);
+  DCHECK_EQ(dispatcher_.size(), 1U);
   dispatcher_.pop_back();
 }
 


### PR DESCRIPTION
Avoid signed-unsigned comparison errors by using unsigned numbers when 
comparing to a size_t.
