### PR TITLE
[Android] Add Resource loading filter for MediaPlayer

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/MediaResourceGetter.java
+++ b/content/public/android/java/src/org/chromium/content/browser/MediaResourceGetter.java
@@ -190,7 +190,7 @@ class MediaResourceGetter {
     boolean configure(Context context, String url, String cookies, String userAgent) {
         Uri uri = Uri.parse(url);
         String scheme = uri.getScheme();
-        if (scheme == null || scheme.equals("file")) {
+        if (scheme == null || scheme.equals("file") || scheme.equals("app")) {
             File file = uriToFile(uri.getPath());
             if (!file.exists()) {
                 Log.e(TAG, "File does not exist.");

--- a/content/renderer/media/android/webmediaplayer_android.cc
+++ b/content/renderer/media/android/webmediaplayer_android.cc
@@ -4,6 +4,7 @@
 
 #include "content/renderer/media/android/webmediaplayer_android.h"
 
+#include <algorithm>
 #include <limits>
 
 #include "base/bind.h"
@@ -571,7 +572,7 @@ void WebMediaPlayerAndroid::OnMediaMetadataChanged(
     const base::TimeDelta& duration, int width, int height, bool success) {
   bool need_to_signal_duration_changed = false;
 
-  if (url_.SchemeIs("file"))
+  if (url_.SchemeIs("file") || url_.SchemeIs("app"))
     UpdateNetworkState(WebMediaPlayer::NetworkStateLoaded);
 
   // Update duration, if necessary, prior to ready state updates that may

--- a/media/base/android/java/src/org/chromium/media/MediaPlayerBridge.java
+++ b/media/base/android/java/src/org/chromium/media/MediaPlayerBridge.java
@@ -33,6 +33,19 @@ import java.util.HashMap;
 @JNINamespace("media")
 public class MediaPlayerBridge {
 
+    public static class ResourceLoadingFilter {
+        public boolean shouldOverrideResourceLoading(
+                MediaPlayer mediaPlayer, Context context, Uri uri) {
+            return false;
+        }
+    }
+
+    private static ResourceLoadingFilter sResourceLoadFilter = null;
+
+    public static void setResourceLoadingFilter(ResourceLoadingFilter filter) {
+        sResourceLoadFilter = filter;
+    }
+
     private static final String TAG = "MediaPlayerBridge";
 
     // Local player to forward this to. We don't initialize it here since the subclass might not
@@ -144,6 +157,11 @@ public class MediaPlayerBridge {
         if (!TextUtils.isEmpty(cookies)) headersMap.put("Cookie", cookies);
         if (!TextUtils.isEmpty(userAgent)) headersMap.put("User-Agent", userAgent);
         try {
+            if (sResourceLoadFilter != null &&
+                    sResourceLoadFilter.shouldOverrideResourceLoading(
+                            getLocalPlayer(), context, uri)) {
+                return true;
+            }
             getLocalPlayer().setDataSource(context, uri, headersMap);
             return true;
         } catch (Exception e) {

--- a/media/base/android/media_player_bridge.cc
+++ b/media/base/android/media_player_bridge.cc
@@ -66,7 +66,7 @@ MediaPlayerBridge::~MediaPlayerBridge() {
 
 void MediaPlayerBridge::Initialize() {
   cookies_.clear();
-  if (url_.SchemeIsFile()) {
+  if (url_.SchemeIsFile() || url_.SchemeIs("app")) {
     ExtractMediaMetadata(url_.spec());
     return;
   }


### PR DESCRIPTION
Why: There are requirements to customize the MediaPlayer resource
loading on Android which is implemented in Chromium code base.
Till now we have two points:
    1) Support the file:///android_asset in MediaPlayer.
    2) Support app scheme in the resource loading of MediaPlayer.
Unfortunately, the resource loading of MediaPlayer on Andoid goes
a different way from other ports and no interface to handle this.

How: Add a new interface ResourceLoadingFilter to filter the resource
loading(setDataSource) in MediaPlayerBridge, which could be used in
xwalk to do the customization by overriding the function of
shouldOverrideResourceLoading() in xwalk.

BUG=https://crosswalk-project.org/jira/browse/XWALK-880
