### PR TITLE
Backport Chromium commits to fix the Ozone build with 35.0.1916.114.

### DIFF
--- a/chrome/browser/ui/browser_command_controller.cc
+++ b/chrome/browser/ui/browser_command_controller.cc
@@ -68,8 +68,8 @@
 #include "chrome/browser/ui/browser_commands_chromeos.h"
 #endif
 
-#if defined(USE_X11) && !defined(OS_CHROMEOS)
-#include "ui/events/x/text_edit_key_bindings_delegate_x11.h"
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+#include "ui/events/linux/text_edit_key_bindings_delegate_auralinux.h"
 #endif
 
 using content::NavigationEntry;
@@ -287,10 +287,10 @@ bool BrowserCommandController::IsReservedCommandOrKey(
   if (window()->IsFullscreen() && command_id == IDC_FULLSCREEN)
     return true;
 
-#if defined(USE_X11) && !defined(OS_CHROMEOS) && !defined(TOOLKIT_GTK)
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS) && !defined(TOOLKIT_GTK)
   // If this key was registered by the user as a content editing hotkey, then
   // it is not reserved.
-  ui::TextEditKeyBindingsDelegateX11* delegate =
+  ui::TextEditKeyBindingsDelegateAuraLinux* delegate =
       ui::GetTextEditKeyBindingsDelegate();
   if (delegate && event.os_event && delegate->MatchEvent(*event.os_event, NULL))
     return false;

--- a/chrome/browser/ui/libgtk2ui/gtk2_key_bindings_handler.cc
+++ b/chrome/browser/ui/libgtk2ui/gtk2_key_bindings_handler.cc
@@ -17,7 +17,7 @@
 #include "ui/base/x/x11_util.h"
 #include "ui/events/event.h"
 
-using ui::TextEditCommandX11;
+using ui::TextEditCommandAuraLinux;
 
 // TODO(erg): Rewrite the old gtk_key_bindings_handler_unittest.cc and get them
 // in a state that links. This code was adapted from the content layer GTK
@@ -48,7 +48,7 @@ Gtk2KeyBindingsHandler::~Gtk2KeyBindingsHandler() {
 
 bool Gtk2KeyBindingsHandler::MatchEvent(
     const ui::Event& event,
-    std::vector<TextEditCommandX11>* edit_commands) {
+    std::vector<TextEditCommandAuraLinux>* edit_commands) {
   CHECK(event.IsKeyEvent());
 
   const ui::KeyEvent& key_event = static_cast<const ui::KeyEvent&>(event);
@@ -88,10 +88,12 @@ GtkWidget* Gtk2KeyBindingsHandler::CreateNewHandler() {
 }
 
 void Gtk2KeyBindingsHandler::EditCommandMatched(
-    TextEditCommandX11::CommandId id,
+    TextEditCommandAuraLinux::CommandId id,
     const std::string& value,
     bool extend_selection) {
-  edit_commands_.push_back(TextEditCommandX11(id, value, extend_selection));
+  edit_commands_.push_back(TextEditCommandAuraLinux(id,
+                                                    value,
+                                                    extend_selection));
 }
 
 void Gtk2KeyBindingsHandler::BuildGdkEventKeyFromXEvent(
@@ -199,17 +201,17 @@ Gtk2KeyBindingsHandler* Gtk2KeyBindingsHandler::GetHandlerOwner(
 void Gtk2KeyBindingsHandler::BackSpace(GtkTextView* text_view) {
   GetHandlerOwner(text_view)
       ->EditCommandMatched(
-          TextEditCommandX11::DELETE_BACKWARD, std::string(), false);
+          TextEditCommandAuraLinux::DELETE_BACKWARD, std::string(), false);
 }
 
 void Gtk2KeyBindingsHandler::CopyClipboard(GtkTextView* text_view) {
   GetHandlerOwner(text_view)->EditCommandMatched(
-      TextEditCommandX11::COPY, std::string(), false);
+      TextEditCommandAuraLinux::COPY, std::string(), false);
 }
 
 void Gtk2KeyBindingsHandler::CutClipboard(GtkTextView* text_view) {
   GetHandlerOwner(text_view)->EditCommandMatched(
-      TextEditCommandX11::CUT, std::string(), false);
+      TextEditCommandAuraLinux::CUT, std::string(), false);
 }
 
 void Gtk2KeyBindingsHandler::DeleteFromCursor(
@@ -217,49 +219,49 @@ void Gtk2KeyBindingsHandler::DeleteFromCursor(
   if (!count)
     return;
 
-  TextEditCommandX11::CommandId commands[2] = {
-    TextEditCommandX11::INVALID_COMMAND,
-    TextEditCommandX11::INVALID_COMMAND,
+  TextEditCommandAuraLinux::CommandId commands[2] = {
+    TextEditCommandAuraLinux::INVALID_COMMAND,
+    TextEditCommandAuraLinux::INVALID_COMMAND,
   };
   switch (type) {
     case GTK_DELETE_CHARS:
       commands[0] = (count > 0 ?
-          TextEditCommandX11::DELETE_FORWARD :
-          TextEditCommandX11::DELETE_BACKWARD);
+          TextEditCommandAuraLinux::DELETE_FORWARD :
+          TextEditCommandAuraLinux::DELETE_BACKWARD);
       break;
     case GTK_DELETE_WORD_ENDS:
       commands[0] = (count > 0 ?
-          TextEditCommandX11::DELETE_WORD_FORWARD :
-          TextEditCommandX11::DELETE_WORD_BACKWARD);
+          TextEditCommandAuraLinux::DELETE_WORD_FORWARD :
+          TextEditCommandAuraLinux::DELETE_WORD_BACKWARD);
       break;
     case GTK_DELETE_WORDS:
       if (count > 0) {
-        commands[0] = TextEditCommandX11::MOVE_WORD_FORWARD;
-        commands[1] = TextEditCommandX11::DELETE_WORD_BACKWARD;
+        commands[0] = TextEditCommandAuraLinux::MOVE_WORD_FORWARD;
+        commands[1] = TextEditCommandAuraLinux::DELETE_WORD_BACKWARD;
       } else {
-        commands[0] = TextEditCommandX11::MOVE_WORD_BACKWARD;
-        commands[1] = TextEditCommandX11::DELETE_WORD_FORWARD;
+        commands[0] = TextEditCommandAuraLinux::MOVE_WORD_BACKWARD;
+        commands[1] = TextEditCommandAuraLinux::DELETE_WORD_FORWARD;
       }
       break;
     case GTK_DELETE_DISPLAY_LINES:
-      commands[0] = TextEditCommandX11::MOVE_TO_BEGINING_OF_LINE;
-      commands[1] = TextEditCommandX11::DELETE_TO_END_OF_LINE;
+      commands[0] = TextEditCommandAuraLinux::MOVE_TO_BEGINING_OF_LINE;
+      commands[1] = TextEditCommandAuraLinux::DELETE_TO_END_OF_LINE;
       break;
     case GTK_DELETE_DISPLAY_LINE_ENDS:
       commands[0] = (count > 0 ?
-          TextEditCommandX11::DELETE_TO_END_OF_LINE :
-          TextEditCommandX11::DELETE_TO_BEGINING_OF_LINE);
+          TextEditCommandAuraLinux::DELETE_TO_END_OF_LINE :
+          TextEditCommandAuraLinux::DELETE_TO_BEGINING_OF_LINE);
       break;
     case GTK_DELETE_PARAGRAPH_ENDS:
       commands[0] = (count > 0 ?
-          TextEditCommandX11::DELETE_TO_END_OF_PARAGRAPH :
-          TextEditCommandX11::DELETE_TO_BEGINING_OF_PARAGRAPH);
+          TextEditCommandAuraLinux::DELETE_TO_END_OF_PARAGRAPH :
+          TextEditCommandAuraLinux::DELETE_TO_BEGINING_OF_PARAGRAPH);
       break;
     case GTK_DELETE_PARAGRAPHS:
       commands[0] =
-          TextEditCommandX11::MOVE_TO_BEGINING_OF_PARAGRAPH;
+          TextEditCommandAuraLinux::MOVE_TO_BEGINING_OF_PARAGRAPH;
       commands[1] =
-          TextEditCommandX11::DELETE_TO_END_OF_PARAGRAPH;
+          TextEditCommandAuraLinux::DELETE_TO_END_OF_PARAGRAPH;
       break;
     default:
       // GTK_DELETE_WHITESPACE has no corresponding editor command.
@@ -271,7 +273,7 @@ void Gtk2KeyBindingsHandler::DeleteFromCursor(
     count = -count;
   for (; count > 0; --count) {
     for (size_t i = 0; i < arraysize(commands); ++i)
-      if (commands[i] != TextEditCommandX11::INVALID_COMMAND)
+      if (commands[i] != TextEditCommandAuraLinux::INVALID_COMMAND)
         owner->EditCommandMatched(commands[i], std::string(), false);
   }
 }
@@ -280,7 +282,7 @@ void Gtk2KeyBindingsHandler::InsertAtCursor(GtkTextView* text_view,
                                             const gchar* str) {
   if (str && *str)
     GetHandlerOwner(text_view)->EditCommandMatched(
-        TextEditCommandX11::INSERT_TEXT, str, false);
+        TextEditCommandAuraLinux::INSERT_TEXT, str, false);
 }
 
 void Gtk2KeyBindingsHandler::MoveCursor(
@@ -289,44 +291,45 @@ void Gtk2KeyBindingsHandler::MoveCursor(
   if (!count)
     return;
 
-  TextEditCommandX11::CommandId command;
+  TextEditCommandAuraLinux::CommandId command;
   switch (step) {
     case GTK_MOVEMENT_LOGICAL_POSITIONS:
       command = (count > 0 ?
-                 TextEditCommandX11::MOVE_FORWARD :
-                 TextEditCommandX11::MOVE_BACKWARD);
+                 TextEditCommandAuraLinux::MOVE_FORWARD :
+                 TextEditCommandAuraLinux::MOVE_BACKWARD);
       break;
     case GTK_MOVEMENT_VISUAL_POSITIONS:
       command = (count > 0 ?
-                 TextEditCommandX11::MOVE_RIGHT :
-                 TextEditCommandX11::MOVE_LEFT);
+                 TextEditCommandAuraLinux::MOVE_RIGHT :
+                 TextEditCommandAuraLinux::MOVE_LEFT);
       break;
     case GTK_MOVEMENT_WORDS:
       command = (count > 0 ?
-                 TextEditCommandX11::MOVE_WORD_RIGHT :
-                 TextEditCommandX11::MOVE_WORD_LEFT);
+                 TextEditCommandAuraLinux::MOVE_WORD_RIGHT :
+                 TextEditCommandAuraLinux::MOVE_WORD_LEFT);
       break;
     case GTK_MOVEMENT_DISPLAY_LINES:
       command = (count > 0 ?
-                 TextEditCommandX11::MOVE_DOWN : TextEditCommandX11::MOVE_UP);
+                 TextEditCommandAuraLinux::MOVE_DOWN :
+                 TextEditCommandAuraLinux::MOVE_UP);
       break;
     case GTK_MOVEMENT_DISPLAY_LINE_ENDS:
       command = (count > 0 ?
-                 TextEditCommandX11::MOVE_TO_END_OF_LINE :
-                 TextEditCommandX11::MOVE_TO_BEGINING_OF_LINE);
+                 TextEditCommandAuraLinux::MOVE_TO_END_OF_LINE :
+                 TextEditCommandAuraLinux::MOVE_TO_BEGINING_OF_LINE);
       break;
     case GTK_MOVEMENT_PARAGRAPH_ENDS:
       command = (count > 0 ?
-                 TextEditCommandX11::MOVE_TO_END_OF_PARAGRAPH :
-                 TextEditCommandX11::MOVE_TO_BEGINING_OF_PARAGRAPH);
+                 TextEditCommandAuraLinux::MOVE_TO_END_OF_PARAGRAPH :
+                 TextEditCommandAuraLinux::MOVE_TO_BEGINING_OF_PARAGRAPH);
       break;
     case GTK_MOVEMENT_PAGES:
-      command = (count > 0 ? TextEditCommandX11::MOVE_PAGE_DOWN :
-                 TextEditCommandX11::MOVE_PAGE_UP);
+      command = (count > 0 ? TextEditCommandAuraLinux::MOVE_PAGE_DOWN :
+                 TextEditCommandAuraLinux::MOVE_PAGE_UP);
       break;
     case GTK_MOVEMENT_BUFFER_ENDS:
-      command = (count > 0 ? TextEditCommandX11::MOVE_TO_END_OF_DOCUMENT :
-                 TextEditCommandX11::MOVE_TO_BEGINING_OF_DOCUMENT);
+      command = (count > 0 ? TextEditCommandAuraLinux::MOVE_TO_END_OF_DOCUMENT :
+                 TextEditCommandAuraLinux::MOVE_TO_BEGINING_OF_DOCUMENT);
       break;
     default:
       // GTK_MOVEMENT_PARAGRAPHS and GTK_MOVEMENT_HORIZONTAL_PAGES have
@@ -348,23 +351,23 @@ void Gtk2KeyBindingsHandler::MoveViewport(
 
 void Gtk2KeyBindingsHandler::PasteClipboard(GtkTextView* text_view) {
   GetHandlerOwner(text_view)->EditCommandMatched(
-      TextEditCommandX11::PASTE, std::string(), false);
+      TextEditCommandAuraLinux::PASTE, std::string(), false);
 }
 
 void Gtk2KeyBindingsHandler::SelectAll(GtkTextView* text_view,
                                        gboolean select) {
   if (select) {
     GetHandlerOwner(text_view)->EditCommandMatched(
-        TextEditCommandX11::SELECT_ALL, std::string(), false);
+        TextEditCommandAuraLinux::SELECT_ALL, std::string(), false);
   } else {
     GetHandlerOwner(text_view)->EditCommandMatched(
-        TextEditCommandX11::UNSELECT, std::string(), false);
+        TextEditCommandAuraLinux::UNSELECT, std::string(), false);
   }
 }
 
 void Gtk2KeyBindingsHandler::SetAnchor(GtkTextView* text_view) {
   GetHandlerOwner(text_view)->EditCommandMatched(
-      TextEditCommandX11::SET_MARK, std::string(), false);
+      TextEditCommandAuraLinux::SET_MARK, std::string(), false);
 }
 
 void Gtk2KeyBindingsHandler::ToggleCursorVisible(GtkTextView* text_view) {

--- a/chrome/browser/ui/libgtk2ui/gtk2_key_bindings_handler.h
+++ b/chrome/browser/ui/libgtk2ui/gtk2_key_bindings_handler.h
@@ -12,7 +12,7 @@
 
 #include "base/event_types.h"
 #include "chrome/browser/ui/libgtk2ui/owned_widget_gtk2.h"
-#include "ui/events/x/text_edit_command_x11.h"
+#include "ui/events/linux/text_edit_command_auralinux.h"
 
 namespace content {
 struct NativeWebKeyboardEvent;
@@ -53,7 +53,7 @@ class Gtk2KeyBindingsHandler {
   // Edit commands matched with |event| will be stored in |edit_commands|, if
   // non-NULL.
   bool MatchEvent(const ui::Event& event,
-                  std::vector<ui::TextEditCommandX11>* commands);
+                  std::vector<ui::TextEditCommandAuraLinux>* commands);
 
  private:
   // Object structure of Handler class, which is derived from GtkTextView.
@@ -71,7 +71,7 @@ class Gtk2KeyBindingsHandler {
   GtkWidget* CreateNewHandler();
 
   // Adds an edit command to the key event.
-  void EditCommandMatched(ui::TextEditCommandX11::CommandId id,
+  void EditCommandMatched(ui::TextEditCommandAuraLinux::CommandId id,
                           const std::string& value,
                           bool extend_selection);
 
@@ -141,7 +141,7 @@ class Gtk2KeyBindingsHandler {
   libgtk2ui::OwnedWidgetGtk handler_;
 
   // Buffer to store the match results.
-  std::vector<ui::TextEditCommandX11> edit_commands_;
+  std::vector<ui::TextEditCommandAuraLinux> edit_commands_;
 
   // Whether the current X server has the XKeyboard extension.
   bool has_xkb_;

--- a/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
+++ b/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
@@ -681,7 +681,7 @@ void Gtk2UI::NotifyWindowManagerStartupComplete() {
 }
 
 bool Gtk2UI::MatchEvent(const ui::Event& event,
-                        std::vector<ui::TextEditCommandX11>* commands) {
+                        std::vector<ui::TextEditCommandAuraLinux>* commands) {
   // Ensure that we have a keyboard handler.
   if (!key_bindings_handler_)
     key_bindings_handler_.reset(new Gtk2KeyBindingsHandler);

--- a/chrome/browser/ui/libgtk2ui/gtk2_ui.h
+++ b/chrome/browser/ui/libgtk2ui/gtk2_ui.h
@@ -15,7 +15,7 @@
 #include "chrome/browser/ui/libgtk2ui/gtk2_signal_registrar.h"
 #include "chrome/browser/ui/libgtk2ui/libgtk2ui_export.h"
 #include "chrome/browser/ui/libgtk2ui/owned_widget_gtk2.h"
-#include "ui/events/x/text_edit_key_bindings_delegate_x11.h"
+#include "ui/events/linux/text_edit_key_bindings_delegate_auralinux.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/views/linux_ui/linux_ui.h"
@@ -115,7 +115,7 @@ class Gtk2UI : public views::LinuxUI {
   // ui::TextEditKeybindingDelegate:
   virtual bool MatchEvent(
       const ui::Event& event,
-      std::vector<ui::TextEditCommandX11>* commands) OVERRIDE;
+      std::vector<ui::TextEditCommandAuraLinux>* commands) OVERRIDE;
 
  private:
   typedef std::map<int, SkColor> ColorMap;

--- a/content/browser/renderer_host/render_widget_host_view_aura.cc
+++ b/content/browser/renderer_host/render_widget_host_view_aura.cc
@@ -94,10 +94,10 @@
 #include "ui/gfx/win/dpi.h"
 #endif
 
-#if defined(USE_X11) && !defined(OS_CHROMEOS)
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
 #include "content/common/input_messages.h"
-#include "ui/events/x/text_edit_command_x11.h"
-#include "ui/events/x/text_edit_key_bindings_delegate_x11.h"
+#include "ui/events/linux/text_edit_command_auralinux.h"
+#include "ui/events/linux/text_edit_key_bindings_delegate_auralinux.h"
 #endif
 
 using gfx::RectToSkIRect;
@@ -3577,17 +3577,17 @@ void RenderWidgetHostViewAura::DetachFromInputMethod() {
 
 void RenderWidgetHostViewAura::ForwardKeyboardEvent(
     const NativeWebKeyboardEvent& event) {
-#if defined(USE_X11) && !defined(OS_CHROMEOS)
-  ui::TextEditKeyBindingsDelegateX11* keybinding_delegate =
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+  ui::TextEditKeyBindingsDelegateAuraLinux* keybinding_delegate =
       ui::GetTextEditKeyBindingsDelegate();
-  std::vector<ui::TextEditCommandX11> commands;
+  std::vector<ui::TextEditCommandAuraLinux> commands;
   if (!event.skip_in_browser &&
       keybinding_delegate &&
       event.os_event &&
       keybinding_delegate->MatchEvent(*event.os_event, &commands)) {
     // Transform from ui/ types to content/ types.
     EditCommands edit_commands;
-    for (std::vector<ui::TextEditCommandX11>::const_iterator it =
+    for (std::vector<ui::TextEditCommandAuraLinux>::const_iterator it =
              commands.begin(); it != commands.end(); ++it) {
       edit_commands.push_back(EditCommand(it->GetCommandString(),
                                           it->argument()));

--- a/ui/events/events.gyp
+++ b/ui/events/events.gyp
@@ -148,10 +148,10 @@
         'platform/x11/x11_event_source.h',
         'win/events_win.cc',
         'x/events_x.cc',
-        'x/text_edit_command_x11.cc',
-        'x/text_edit_command_x11.h',
-        'x/text_edit_key_bindings_delegate_x11.cc',
-        'x/text_edit_key_bindings_delegate_x11.h',
+        'linux/text_edit_command_auralinux.cc',
+        'linux/text_edit_command_auralinux.h',
+        'linux/text_edit_key_bindings_delegate_auralinux.cc',
+        'linux/text_edit_key_bindings_delegate_auralinux.h',
       ],
       'conditions': [
         # We explicitly enumerate the platforms we _do_ provide native cracking
@@ -163,10 +163,10 @@
         }],
         ['chromeos==1', {
           'sources!': [
-            'x/text_edit_command_x11.cc',
-            'x/text_edit_command_x11.h',
-            'x/text_edit_key_bindings_delegate_x11.cc',
-            'x/text_edit_key_bindings_delegate_x11.h',
+            'linux/text_edit_command_auralinux.cc',
+            'linux/text_edit_command_auralinux.h',
+            'linux/text_edit_key_bindings_delegate_auralinux.cc',
+            'linux/text_edit_key_bindings_delegate_auralinux.h',
           ],
         }],
         ['use_x11==1', {

--- a/ui/events/linux/text_edit_command_auralinux.cc
+++ b/ui/events/linux/text_edit_command_auralinux.cc
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "ui/events/x/text_edit_command_x11.h"
+#include "ui/events/linux/text_edit_command_auralinux.h"
 
 #include "base/logging.h"
 
 namespace ui {
 
-std::string TextEditCommandX11::GetCommandString() const {
+std::string TextEditCommandAuraLinux::GetCommandString() const {
   std::string base_name;
   switch (command_id_) {
     case COPY:
@@ -122,4 +122,3 @@ std::string TextEditCommandX11::GetCommandString() const {
 }
 
 }  // namespace ui
-

--- a/ui/events/linux/text_edit_command_auralinux.h
+++ b/ui/events/linux/text_edit_command_auralinux.h
@@ -13,7 +13,7 @@ namespace ui {
 
 // Represents a command that performs a specific operation on text.
 // Copy and assignment are explicitly allowed; these objects live in vectors.
-class EVENTS_EXPORT TextEditCommandX11 {
+class EVENTS_EXPORT TextEditCommandAuraLinux {
  public:
   enum CommandId {
     COPY,
@@ -52,7 +52,7 @@ class EVENTS_EXPORT TextEditCommandX11 {
     INVALID_COMMAND
   };
 
-  TextEditCommandX11(CommandId command_id,
+  TextEditCommandAuraLinux(CommandId command_id,
                      const std::string& argument,
                      bool extend_selection)
       : command_id_(command_id),

--- a/ui/events/linux/text_edit_key_bindings_delegate_auralinux.cc
+++ b/ui/events/linux/text_edit_key_bindings_delegate_auralinux.cc
@@ -2,20 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "ui/events/x/text_edit_key_bindings_delegate_x11.h"
+#include "ui/events/linux/text_edit_key_bindings_delegate_auralinux.h"
 
 namespace ui {
 
 namespace {
 // Optional delegate. Unowned pointer.
-TextEditKeyBindingsDelegateX11* text_edit_keybinding_delegate_ = 0;
+TextEditKeyBindingsDelegateAuraLinux* text_edit_keybinding_delegate_ = 0;
 }
 
-void SetTextEditKeyBindingsDelegate(TextEditKeyBindingsDelegateX11* delegate) {
+void SetTextEditKeyBindingsDelegate(
+     TextEditKeyBindingsDelegateAuraLinux* delegate) {
   text_edit_keybinding_delegate_ = delegate;
 }
 
-TextEditKeyBindingsDelegateX11* GetTextEditKeyBindingsDelegate() {
+TextEditKeyBindingsDelegateAuraLinux* GetTextEditKeyBindingsDelegate() {
   return text_edit_keybinding_delegate_;
 }
 

--- a/ui/events/linux/text_edit_key_bindings_delegate_auralinux.h
+++ b/ui/events/linux/text_edit_key_bindings_delegate_auralinux.h
@@ -11,31 +11,32 @@
 
 namespace ui {
 class Event;
-class TextEditCommandX11;
+class TextEditCommandAuraLinux;
 
 // An interface which can interpret various text editing commands out of key
 // events.
 //
 // On desktop Linux, we've traditionally supported the user's custom
 // keybindings. We need to support this in both content/ and in views/.
-class EVENTS_EXPORT TextEditKeyBindingsDelegateX11 {
+class EVENTS_EXPORT TextEditKeyBindingsDelegateAuraLinux {
  public:
   // Matches a key event against the users' platform specific key bindings,
   // false will be returned if the key event doesn't correspond to a predefined
   // key binding.  Edit commands matched with |event| will be stored in
   // |edit_commands|, if |edit_commands| is non-NULL.
   virtual bool MatchEvent(const ui::Event& event,
-                          std::vector<TextEditCommandX11>* commands) = 0;
+                          std::vector<TextEditCommandAuraLinux>* commands) = 0;
 
  protected:
-  virtual ~TextEditKeyBindingsDelegateX11() {}
+  virtual ~TextEditKeyBindingsDelegateAuraLinux() {}
 };
 
-// Sets/Gets the global TextEditKeyBindingsDelegateX11. No ownership
+// Sets/Gets the global TextEditKeyBindingsDelegateAuraLinux. No ownership
 // changes. Can be NULL.
 EVENTS_EXPORT void SetTextEditKeyBindingsDelegate(
-    TextEditKeyBindingsDelegateX11* delegate);
-EVENTS_EXPORT TextEditKeyBindingsDelegateX11* GetTextEditKeyBindingsDelegate();
+    TextEditKeyBindingsDelegateAuraLinux* delegate);
+EVENTS_EXPORT TextEditKeyBindingsDelegateAuraLinux*
+    GetTextEditKeyBindingsDelegate();
 
 }  // namespace ui
 

--- a/ui/views/controls/textfield/textfield.cc
+++ b/ui/views/controls/textfield/textfield.cc
@@ -42,8 +42,8 @@
 
 #if defined(OS_LINUX) && !defined(OS_CHROMEOS)
 #include "base/strings/utf_string_conversions.h"
-#include "ui/events/x/text_edit_command_x11.h"
-#include "ui/events/x/text_edit_key_bindings_delegate_x11.h"
+#include "ui/events/linux/text_edit_command_auralinux.h"
+#include "ui/events/linux/text_edit_key_bindings_delegate_auralinux.h"
 #endif
 
 namespace views {
@@ -136,85 +136,85 @@ int GetCommandForKeyEvent(const ui::KeyEvent& event, bool has_selection) {
 }
 
 #if defined(OS_LINUX) && !defined(OS_CHROMEOS)
-int GetViewsCommand(const ui::TextEditCommandX11& command, bool rtl) {
+int GetViewsCommand(const ui::TextEditCommandAuraLinux& command, bool rtl) {
   const bool select = command.extend_selection();
   switch (command.command_id()) {
-    case ui::TextEditCommandX11::COPY:
+    case ui::TextEditCommandAuraLinux::COPY:
       return IDS_APP_COPY;
-    case ui::TextEditCommandX11::CUT:
+    case ui::TextEditCommandAuraLinux::CUT:
       return IDS_APP_CUT;
-    case ui::TextEditCommandX11::DELETE_BACKWARD:
+    case ui::TextEditCommandAuraLinux::DELETE_BACKWARD:
       return IDS_DELETE_BACKWARD;
-    case ui::TextEditCommandX11::DELETE_FORWARD:
+    case ui::TextEditCommandAuraLinux::DELETE_FORWARD:
       return IDS_DELETE_FORWARD;
-    case ui::TextEditCommandX11::DELETE_TO_BEGINING_OF_LINE:
-    case ui::TextEditCommandX11::DELETE_TO_BEGINING_OF_PARAGRAPH:
+    case ui::TextEditCommandAuraLinux::DELETE_TO_BEGINING_OF_LINE:
+    case ui::TextEditCommandAuraLinux::DELETE_TO_BEGINING_OF_PARAGRAPH:
       return IDS_DELETE_TO_BEGINNING_OF_LINE;
-    case ui::TextEditCommandX11::DELETE_TO_END_OF_LINE:
-    case ui::TextEditCommandX11::DELETE_TO_END_OF_PARAGRAPH:
+    case ui::TextEditCommandAuraLinux::DELETE_TO_END_OF_LINE:
+    case ui::TextEditCommandAuraLinux::DELETE_TO_END_OF_PARAGRAPH:
       return IDS_DELETE_TO_END_OF_LINE;
-    case ui::TextEditCommandX11::DELETE_WORD_BACKWARD:
+    case ui::TextEditCommandAuraLinux::DELETE_WORD_BACKWARD:
       return IDS_DELETE_WORD_BACKWARD;
-    case ui::TextEditCommandX11::DELETE_WORD_FORWARD:
+    case ui::TextEditCommandAuraLinux::DELETE_WORD_FORWARD:
       return IDS_DELETE_WORD_FORWARD;
-    case ui::TextEditCommandX11::INSERT_TEXT:
+    case ui::TextEditCommandAuraLinux::INSERT_TEXT:
       return kNoCommand;
-    case ui::TextEditCommandX11::MOVE_BACKWARD:
+    case ui::TextEditCommandAuraLinux::MOVE_BACKWARD:
       if (rtl)
         return select ? IDS_MOVE_RIGHT_AND_MODIFY_SELECTION : IDS_MOVE_RIGHT;
       return select ? IDS_MOVE_LEFT_AND_MODIFY_SELECTION : IDS_MOVE_LEFT;
-    case ui::TextEditCommandX11::MOVE_DOWN:
+    case ui::TextEditCommandAuraLinux::MOVE_DOWN:
       return IDS_MOVE_DOWN;
-    case ui::TextEditCommandX11::MOVE_FORWARD:
+    case ui::TextEditCommandAuraLinux::MOVE_FORWARD:
       if (rtl)
         return select ? IDS_MOVE_LEFT_AND_MODIFY_SELECTION : IDS_MOVE_LEFT;
       return select ? IDS_MOVE_RIGHT_AND_MODIFY_SELECTION : IDS_MOVE_RIGHT;
-    case ui::TextEditCommandX11::MOVE_LEFT:
+    case ui::TextEditCommandAuraLinux::MOVE_LEFT:
       return select ? IDS_MOVE_LEFT_AND_MODIFY_SELECTION : IDS_MOVE_LEFT;
-    case ui::TextEditCommandX11::MOVE_PAGE_DOWN:
-    case ui::TextEditCommandX11::MOVE_PAGE_UP:
+    case ui::TextEditCommandAuraLinux::MOVE_PAGE_DOWN:
+    case ui::TextEditCommandAuraLinux::MOVE_PAGE_UP:
       return kNoCommand;
-    case ui::TextEditCommandX11::MOVE_RIGHT:
+    case ui::TextEditCommandAuraLinux::MOVE_RIGHT:
       return select ? IDS_MOVE_RIGHT_AND_MODIFY_SELECTION : IDS_MOVE_RIGHT;
-    case ui::TextEditCommandX11::MOVE_TO_BEGINING_OF_DOCUMENT:
-    case ui::TextEditCommandX11::MOVE_TO_BEGINING_OF_LINE:
-    case ui::TextEditCommandX11::MOVE_TO_BEGINING_OF_PARAGRAPH:
+    case ui::TextEditCommandAuraLinux::MOVE_TO_BEGINING_OF_DOCUMENT:
+    case ui::TextEditCommandAuraLinux::MOVE_TO_BEGINING_OF_LINE:
+    case ui::TextEditCommandAuraLinux::MOVE_TO_BEGINING_OF_PARAGRAPH:
       return select ? IDS_MOVE_TO_BEGINNING_OF_LINE_AND_MODIFY_SELECTION :
                       IDS_MOVE_TO_BEGINNING_OF_LINE;
-    case ui::TextEditCommandX11::MOVE_TO_END_OF_DOCUMENT:
-    case ui::TextEditCommandX11::MOVE_TO_END_OF_LINE:
-    case ui::TextEditCommandX11::MOVE_TO_END_OF_PARAGRAPH:
+    case ui::TextEditCommandAuraLinux::MOVE_TO_END_OF_DOCUMENT:
+    case ui::TextEditCommandAuraLinux::MOVE_TO_END_OF_LINE:
+    case ui::TextEditCommandAuraLinux::MOVE_TO_END_OF_PARAGRAPH:
       return select ? IDS_MOVE_TO_END_OF_LINE_AND_MODIFY_SELECTION :
                       IDS_MOVE_TO_END_OF_LINE;
-    case ui::TextEditCommandX11::MOVE_UP:
+    case ui::TextEditCommandAuraLinux::MOVE_UP:
       return IDS_MOVE_UP;
-    case ui::TextEditCommandX11::MOVE_WORD_BACKWARD:
+    case ui::TextEditCommandAuraLinux::MOVE_WORD_BACKWARD:
       if (rtl) {
         return select ? IDS_MOVE_WORD_RIGHT_AND_MODIFY_SELECTION :
                         IDS_MOVE_WORD_RIGHT;
       }
       return select ? IDS_MOVE_WORD_LEFT_AND_MODIFY_SELECTION :
                       IDS_MOVE_WORD_LEFT;
-    case ui::TextEditCommandX11::MOVE_WORD_FORWARD:
+    case ui::TextEditCommandAuraLinux::MOVE_WORD_FORWARD:
       if (rtl) {
         return select ? IDS_MOVE_WORD_LEFT_AND_MODIFY_SELECTION :
                         IDS_MOVE_WORD_LEFT;
       }
       return select ? IDS_MOVE_WORD_RIGHT_AND_MODIFY_SELECTION :
                       IDS_MOVE_WORD_RIGHT;
-    case ui::TextEditCommandX11::MOVE_WORD_LEFT:
+    case ui::TextEditCommandAuraLinux::MOVE_WORD_LEFT:
       return select ? IDS_MOVE_WORD_LEFT_AND_MODIFY_SELECTION :
                       IDS_MOVE_WORD_LEFT;
-    case ui::TextEditCommandX11::MOVE_WORD_RIGHT:
+    case ui::TextEditCommandAuraLinux::MOVE_WORD_RIGHT:
       return select ? IDS_MOVE_WORD_RIGHT_AND_MODIFY_SELECTION :
                       IDS_MOVE_WORD_RIGHT;
-    case ui::TextEditCommandX11::PASTE:
+    case ui::TextEditCommandAuraLinux::PASTE:
       return IDS_APP_PASTE;
-    case ui::TextEditCommandX11::SELECT_ALL:
+    case ui::TextEditCommandAuraLinux::SELECT_ALL:
       return IDS_APP_SELECT_ALL;
-    case ui::TextEditCommandX11::SET_MARK:
-    case ui::TextEditCommandX11::UNSELECT:
-    case ui::TextEditCommandX11::INVALID_COMMAND:
+    case ui::TextEditCommandAuraLinux::SET_MARK:
+    case ui::TextEditCommandAuraLinux::UNSELECT:
+    case ui::TextEditCommandAuraLinux::INVALID_COMMAND:
       return kNoCommand;
   }
   return kNoCommand;
@@ -592,9 +592,9 @@ bool Textfield::OnKeyPressed(const ui::KeyEvent& event) {
     return true;
 
 #if defined(OS_LINUX) && !defined(OS_CHROMEOS)
-  ui::TextEditKeyBindingsDelegateX11* delegate =
+  ui::TextEditKeyBindingsDelegateAuraLinux* delegate =
       ui::GetTextEditKeyBindingsDelegate();
-  std::vector<ui::TextEditCommandX11> commands;
+  std::vector<ui::TextEditCommandAuraLinux> commands;
   if (delegate) {
     if (!delegate->MatchEvent(event, &commands))
       return false;
@@ -710,9 +710,9 @@ void Textfield::AboutToRequestFocusFromTabTraversal(bool reverse) {
 bool Textfield::SkipDefaultKeyEventProcessing(const ui::KeyEvent& event) {
 #if defined(OS_LINUX) && !defined(OS_CHROMEOS)
   // Skip any accelerator handling that conflicts with custom keybindings.
-  ui::TextEditKeyBindingsDelegateX11* delegate =
+  ui::TextEditKeyBindingsDelegateAuraLinux* delegate =
       ui::GetTextEditKeyBindingsDelegate();
-  std::vector<ui::TextEditCommandX11> commands;
+  std::vector<ui::TextEditCommandAuraLinux> commands;
   if (delegate && delegate->MatchEvent(event, &commands)) {
     const bool rtl = GetTextDirection() == base::i18n::RIGHT_TO_LEFT;
     for (size_t i = 0; i < commands.size(); ++i)

--- a/ui/views/linux_ui/linux_ui.h
+++ b/ui/views/linux_ui/linux_ui.h
@@ -9,7 +9,7 @@
 
 #include "third_party/skia/include/core/SkColor.h"
 #include "ui/base/ime/linux/linux_input_method_context_factory.h"
-#include "ui/events/x/text_edit_key_bindings_delegate_x11.h"
+#include "ui/events/linux/text_edit_key_bindings_delegate_auralinux.h"
 #include "ui/gfx/linux_font_delegate.h"
 #include "ui/shell_dialogs/linux_shell_dialog.h"
 #include "ui/views/controls/button/button.h"
@@ -44,7 +44,7 @@ class WindowButtonOrderObserver;
 class VIEWS_EXPORT LinuxUI : public ui::LinuxInputMethodContextFactory,
                              public gfx::LinuxFontDelegate,
                              public ui::LinuxShellDialog,
-                             public ui::TextEditKeyBindingsDelegateX11 {
+                             public ui::TextEditKeyBindingsDelegateAuraLinux {
  public:
   virtual ~LinuxUI() {}
 


### PR DESCRIPTION
These are a bunch of commits required to make the build with Ozone work
again after moving Chromium to 35.0.1916.114, caused by r260900.

They were unfortunately rejected for merging into M35 in Chromium
itself[1], but we need them nonetheless for our Wayland builds.

[1] http://code.google.com/p/chromium/issues/detail?id=372340
