### PR TITLE
[Backport] Do not check GTK+ dependencies when use_ozone is defined.

### DIFF
--- a/build/linux/system.gyp
+++ b/build/linux/system.gyp
@@ -22,9 +22,9 @@
     'linux_link_libbrlapi%': 0,
   },
   'conditions': [
-    [ 'chromeos==0', {
-      # Hide GTK and related dependencies for Chrome OS, so they won't get
-      # added back to Chrome OS. Don't try to use GTK on Chrome OS.
+    [ 'chromeos==0 and use_ozone==0', {
+      # Hide GTK and related dependencies for Chrome OS and Ozone, so they won't get
+      # added back to Chrome OS and Ozone. Don't try to use GTK on Chrome OS and Ozone.
       'targets': [
         {
           'target_name': 'gdk',


### PR DESCRIPTION
Author: "joone.hur@intel.com"

glib is not included in ozone platform:
https://codereview.chromium.org/249583003

Therefore, we do not need to check GTK+ dependencies when use_ozone is defined.

Review URL: https://codereview.chromium.org/272743002
git-svn-id: svn://svn.chromium.org/chrome/trunk/src@269373
