### PR TITLE
[Extensions] Build glib message pump on Ozone

### DIFF
--- a/base/base.gypi
+++ b/base/base.gypi
@@ -888,11 +888,6 @@
               'strings/string16.cc',
             ],
           },],
-          ['<(use_ozone) == 1', {
-            'sources!': [
-              'message_loop/message_pump_glib.cc',
-            ]
-          }],
           ['OS == "linux" and >(nacl_untrusted_build)==0', {
             'sources!': [
               'files/file_path_watcher_kqueue.cc',


### PR DESCRIPTION
The GLib mainloop is desired on the Extension Process (only) to ease
the integration with DBus based services.

The patch won't make glib the default, but will make it possible to use
it if explicitly declared.
