### PR TITLE
Provide a ScreenOrientationDispatcherHost getter.

### DIFF
--- a/content/browser/renderer_host/render_process_host_impl.h
+++ b/content/browser/renderer_host/render_process_host_impl.h
@@ -143,6 +143,11 @@ class CONTENT_EXPORT RenderProcessHostImpl
 
   // ChildProcessLauncher::Client implementation.
   virtual void OnProcessLaunched() OVERRIDE;
+  
+  virtual ScreenOrientationDispatcherHost* GetScreenOrientationDispatcherHost()
+      OVERRIDE {
+    return screen_orientation_dispatcher_host_;
+  }
 
   scoped_refptr<AudioRendererHost> audio_renderer_host() const;
 

--- a/content/public/browser/render_process_host.h
+++ b/content/public/browser/render_process_host.h
@@ -27,6 +27,7 @@ class BrowserContext;
 class BrowserMessageFilter;
 class RenderProcessHostObserver;
 class RenderWidgetHost;
+class ScreenOrientationDispatcherHost;
 class StoragePartition;
 struct GlobalRequestID;
 
@@ -214,6 +215,10 @@ class CONTENT_EXPORT RenderProcessHost : public IPC::Sender,
   // Notifies the renderer that the timezone configuration of the system might
   // have changed.
   virtual void NotifyTimezoneChange() = 0;
+  
+  // Returns message filter and dispatcher for screen orientation.
+  virtual ScreenOrientationDispatcherHost* GetScreenOrientationDispatcherHost()
+      = 0;
 
   // Static management functions -----------------------------------------------
 


### PR DESCRIPTION
SSIA. We need it in order to be able to set ScreenOrientationProvider
from Xwalk.
