### PR TITLE
Provide a ScreenOrientationDispatcherHost getter.

### DIFF
--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -853,6 +853,11 @@ void RenderProcessHostImpl::NotifyTimezoneChange() {
   Send(new ViewMsg_TimezoneChange());
 }
 
+ScreenOrientationDispatcherHost* RenderProcessHostImpl
+    ::GetScreenOrientationDispatcherHost() {
+  return screen_orientation_dispatcher_host_;
+}
+
 void RenderProcessHostImpl::AddRoute(
     int32 routing_id,
     IPC::Listener* listener) {

--- a/content/browser/renderer_host/render_process_host_impl.h
+++ b/content/browser/renderer_host/render_process_host_impl.h
@@ -133,6 +133,9 @@ class CONTENT_EXPORT RenderProcessHostImpl
       OVERRIDE;
   virtual void NotifyTimezoneChange() OVERRIDE;
 
+  virtual ScreenOrientationDispatcherHost* GetScreenOrientationDispatcherHost()
+      OVERRIDE;
+
   // IPC::Sender via RenderProcessHost.
   virtual bool Send(IPC::Message* msg) OVERRIDE;
 

--- a/content/public/browser/render_process_host.h
+++ b/content/public/browser/render_process_host.h
@@ -27,6 +27,7 @@ class BrowserContext;
 class BrowserMessageFilter;
 class RenderProcessHostObserver;
 class RenderWidgetHost;
+class ScreenOrientationDispatcherHost;
 class StoragePartition;
 struct GlobalRequestID;
 
@@ -214,6 +215,10 @@ class CONTENT_EXPORT RenderProcessHost : public IPC::Sender,
   // Notifies the renderer that the timezone configuration of the system might
   // have changed.
   virtual void NotifyTimezoneChange() = 0;
+
+  // Returns message filter and dispatcher for screen orientation.
+  virtual ScreenOrientationDispatcherHost* GetScreenOrientationDispatcherHost()
+      = 0;
 
   // Static management functions -----------------------------------------------
 

--- a/content/public/test/mock_render_process_host.cc
+++ b/content/public/test/mock_render_process_host.cc
@@ -227,6 +227,11 @@ void MockRenderProcessHost::FilterURL(bool empty_allowed, GURL* url) {
   RenderProcessHostImpl::FilterURL(this, empty_allowed, url);
 }
 
+ScreenOrientationDispatcherHost* MockRenderProcessHost
+    ::GetScreenOrientationDispatcherHost() {
+  return NULL;
+}
+
 #if defined(ENABLE_WEBRTC)
 void MockRenderProcessHost::EnableAecDump(const base::FilePath& file) {
 }

--- a/content/public/test/mock_render_process_host.h
+++ b/content/public/test/mock_render_process_host.h
@@ -82,6 +82,9 @@ class MockRenderProcessHost : public RenderProcessHost {
       OVERRIDE;
   virtual void NotifyTimezoneChange() OVERRIDE;
 
+  virtual ScreenOrientationDispatcherHost* GetScreenOrientationDispatcherHost()
+      OVERRIDE;
+
   // IPC::Sender via RenderProcessHost.
   virtual bool Send(IPC::Message* msg) OVERRIDE;
 


### PR DESCRIPTION
SSIA. We need it in order to be able to set ScreenOrientationProvider
from Xwalk.
