### PR TITLE
[Android] Add code path for initializing ContentReadbackHandler

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/ContentViewRenderView.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ContentViewRenderView.java
@@ -167,6 +167,7 @@ public class ContentViewRenderView extends FrameLayout implements WindowAndroid.
 
         mRootWindow = rootWindow;
         rootWindow.setVSyncClient(this);
+        initContentReadbackHandler();
 
         mCompositingSurfaceType = surfaceType;
         if (surfaceType == CompositingSurfaceType.TEXTURE_VIEW) {
@@ -223,6 +224,9 @@ public class ContentViewRenderView extends FrameLayout implements WindowAndroid.
                         FrameLayout.LayoutParams.MATCH_PARENT,
                         FrameLayout.LayoutParams.MATCH_PARENT));
 
+    }
+
+    private void initContentReadbackHandler() {
         mContentReadbackHandler = new ContentReadbackHandler() {
             @Override
             protected boolean readyForReadback() {


### PR DESCRIPTION
ContentReadbackHandler initialization is newly added from chromium
36.0.1985. We need to init it for TextureView path to avoid crash on
destroying.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1887
