### PR TITLE
[Tizen] Fixed screen displayed abnormally when playing some size of html5 mp4 videos.

### DIFF
--- a/content/common/gpu/media/vaapi_video_decode_accelerator_wayland.cc
+++ b/content/common/gpu/media/vaapi_video_decode_accelerator_wayland.cc
@@ -190,6 +190,16 @@ bool VaapiVideoDecodeAccelerator::TFPPicture::Upload(VASurfaceID surface) {
   gfx::ScopedTextureBinder texture_binder(GL_TEXTURE_2D, texture_id_);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
+  unsigned int al = 4 * size_.width();
+  if (al != va_image_.pitches[0]) {
+    // Not aligned phenomenon occurs only in special size video in None-X11.
+    // So re-check RGBA data alignment and realign filled video frame in need.
+    unsigned char* bhandle = static_cast<unsigned char*>(buffer);
+    for (int i = 0; i < size_.height(); i++) {
+      memcpy(bhandle + (i * al), bhandle + (i * (va_image_.pitches[0])), al);
+    }
+  }
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, size_.width(), size_.height(),
                0, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
 


### PR DESCRIPTION
[Tizen] Fixed screen displayed abnormally when playing some size of html5 mp4 videos.

BUG=XWALK-1781 (https://crosswalk-project.org/jira/browse/XWALK-1781)
