### PR TITLE
Enable Blink Screen Orientation [Lock] for Android

### DIFF
--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -44,6 +44,7 @@ static void SetRuntimeFeatureDefaultsForPlatform() {
   // Android does not yet support NavigatorContentUtils.
   WebRuntimeFeatures::enableNavigatorContentUtils(false);
   WebRuntimeFeatures::enableTouchIconLoading(true);
+  WebRuntimeFeatures::enableScreenOrientation(true);
   WebRuntimeFeatures::enableOrientationEvent(true);
 #else
   WebRuntimeFeatures::enableNavigatorContentUtils(true);


### PR DESCRIPTION
Enable the Blink implementation of Screen Orientation spec. 

This is more aligned with the spec and the way forward.

Some of the tests might need to be updated as the onorientationchange listener moved from
window.screen to screen and the lockOrientation only takes one argument now.
