### PR TITLE
[Extensions] Build glib message pump on Ozone

### DIFF
--- a/base/base.gyp
+++ b/base/base.gyp
@@ -54,7 +54,7 @@
               ['exclude', '_nss\\.cc$'],
             ],
         }],
-        ['use_glib==1', {
+        ['use_glib==1 or <(use_ozone)==1', {
           'dependencies': [
             '../build/linux/system.gyp:glib',
           ],

--- a/base/base.gypi
+++ b/base/base.gypi
@@ -728,7 +728,7 @@
                 'atomicops_internals_x86_gcc.cc',
               ],
           }],
-          ['<(use_glib)==0 or >(nacl_untrusted_build)==1', {
+          ['(<(use_glib)==0 and <(use_ozone)==0) or >(nacl_untrusted_build)==1', {
               'sources!': [
                 'message_loop/message_pump_glib.cc',
               ],


### PR DESCRIPTION
Squash this patch with the patch with the same name on the next rebase.

Follow-up patch fixing linking errors when using glib on Ozone and not
building component=shared_library.
