### PR TITLE
[Android] Fix the crash of GetUserMedia

### DIFF
--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -4,6 +4,9 @@
 
 #include "media/audio/android/audio_manager_android.h"
 
+#include <algorithm>
+#include <string>
+
 #include "base/android/build_info.h"
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
@@ -236,8 +239,19 @@ AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
     DVLOG(1) << "Creating AudioRecordInputStream";
     return new AudioRecordInputStream(this, params);
   }
+
+  // TODO(xingnan): Crash will happen in the openSL ES library on some IA
+  // devices like ZTE Geek V975, Use AudioRecordInputStream path instead as
+  // a workaround. Will fall back after the fix of the bug.
+#if defined(ARCH_CPU_X86)
+  if (base::android::BuildInfo::GetInstance()->sdk_int() < 16)
+    return NULL;
+  DVLOG(1) << "Creating AudioRecordInputStream";
+  return new AudioRecordInputStream(this, params);
+#else
   DVLOG(1) << "Creating OpenSLESInputStream";
   return new OpenSLESInputStream(this, params);
+#endif
 }
 
 // static


### PR DESCRIPTION
Crash happens when releasing the audio resource of localusermedia in
openSL ES. On Android there are two ways to get the audio input:
openSL ES and java Recording API. We swtich to the Recording API as a
workaround of the bug. The limitation is Recording API only be avaiable
after version 15 of SDK.

BUG=XWALK-1833

Cherry picked from commit dcf89f94921e4fb71021213218991aa96331726e
