### PR TITLE
[Android] Cherry-pick r278950 (0e40ce9) from upstream

### DIFF
--- a/content/child/child_thread.cc
+++ b/content/child/child_thread.cc
@@ -265,11 +265,16 @@ void ChildThread::Init() {
 
   channel_->AddFilter(histogram_message_filter_.get());
   channel_->AddFilter(sync_message_filter_.get());
-  channel_->AddFilter(new tracing::ChildTraceMessageFilter(
-      ChildProcess::current()->io_message_loop_proxy()));
   channel_->AddFilter(resource_message_filter_.get());
   channel_->AddFilter(quota_message_filter_->GetFilter());
   channel_->AddFilter(service_worker_message_filter_->GetFilter());
+
+  if (!CommandLine::ForCurrentProcess()->HasSwitch(switches::kSingleProcess)) {
+    // In single process mode, browser-side tracing will cover the whole
+    // process including renderers.
+    channel_->AddFilter(new tracing::ChildTraceMessageFilter(
+        ChildProcess::current()->io_message_loop_proxy()));
+  }
 
   // In single process mode we may already have a power monitor
   if (!base::PowerMonitor::Get()) {


### PR DESCRIPTION
Author: mnaganov@chromium.org

Disable ChildTraceMessageFilter in single process mode

This fixes chrome://inspect traces for Android WebView.

ChildTraceMessageFilter instances are all talking to the same TraceLog
instance and confuse it. Enabling tracing in browser is enough, since
everyone lives in the same process.

Review URL: https://codereview.chromium.org/349633003

BUG=XWALK-1571
