### PR TITLE
[Android] Implement ScreenOrientation.unlock align with spec

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -355,6 +355,7 @@ Sevan Janiyan <venture37@geeklan.co.uk>
 ShankarGanesh K <blr.bmlab@gmail.com>
 Shez Baig <sbaig1@bloomberg.net>
 Shiliu Wang <aofdwsl@gmail.com>
+Shiliu Wang <shiliu.wang@intel.com>
 Shouqun Liu <shouqun.liu@intel.com>
 Shreyas VA <v.a.shreyas@gmail.com>
 Simon Arlott <simon.arlott@gmail.com>

--- a/content/public/android/java/src/org/chromium/content/browser/ScreenOrientationProvider.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ScreenOrientationProvider.java
@@ -6,6 +6,7 @@ package org.chromium.content.browser;
 
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.util.Log;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -74,7 +75,17 @@ class ScreenOrientationProvider {
             return;
         }
 
-        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        int defaultOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+
+        try {
+            ActivityInfo info = activity.getPackageManager().getActivityInfo(
+                    activity.getComponentName(), PackageManager.GET_META_DATA);
+            defaultOrientation = info.screenOrientation;
+        } catch (PackageManager.NameNotFoundException e) {
+            // Do nothing, defaultOrientation should be SCREEN_ORIENTATION_UNSPECIFIED.
+        } finally {
+            activity.setRequestedOrientation(defaultOrientation);
+        }
     }
 
     private ScreenOrientationProvider() {


### PR DESCRIPTION
This is for compliance with ScreenOrientation
(https://w3c.github.io/screen-orientation).

When unlock screen orientation, it should lock the orientation
to default orientation.
Previous implementation is to set the orientation to "unspecified",
which is not fully aligned with spec.

Instead, read the configuration from the activity metadata in
AndroidManifest.xml and set the orientation accordingly.

BUG=394214

Review URL: https://codereview.chromium.org/399553002

git-svn-id: svn://svn.chromium.org/chrome/trunk/src@284396 0039d316-1c4b-4281-b951-d872f2087c98
(cherry picked from commit 11420f58b5bd1ea957624f482ec0c8b45245ab14)
