### PR TITLE
[Temp][Tizen] Temporarily remove ozone dependency for gl

### DIFF
--- a/ui/gl/gl.gyp
+++ b/ui/gl/gl.gyp
@@ -295,11 +295,6 @@
         ['OS!="android"', {
           'sources/': [ ['exclude', '^android/'] ],
         }],
-        ['use_ozone==1', {
-          'dependencies': [
-            '../ozone/ozone.gyp:ozone',
-          ],
-        }],
         ['OS=="android" and android_webview_build==0', {
           'dependencies': [
             '../android/ui_android.gyp:ui_java',


### PR DESCRIPTION
Currently, the ozone-wayland depends on ui/gl. However, that will cause cycling
dependency error. So temporarily remove ozone dependency for gl until we find a
better way.

Refer to https://github.com/01org/ozone-wayland/issues/240 and
https://github.com/01org/ozone-wayland/pull/246
