### PR TITLE
[Temp] Roll ANGLE to 5ac2ae3ea1f311be61955b2d554e8510474cf4f0.

### DIFF
--- a/.DEPS.git
+++ b/.DEPS.git
@@ -11,7 +11,7 @@ vars = {
     'webkit_rev':
          '@f35b0cb58d8f1d16e8794f73805e9cfa1c9e6fa9',
     'angle_revision':
-         'ebba7d306b34a56f57ff1b87682bdc67cc9c50f8'
+         '5ac2ae3ea1f311be61955b2d554e8510474cf4f0'
 }
 
 deps = {

--- a/DEPS
+++ b/DEPS
@@ -339,7 +339,7 @@ deps = {
   'src/sdch/open-vcdiff':
     (Var("open-vcdiff")) + '/trunk@42',
   'src/third_party/angle':
-    (Var("git.chromium.org")) + '/angle/angle.git@ebba7d306b34a56f57ff1b87682bdc67cc9c50f8',
+    (Var("git.chromium.org")) + '/angle/angle.git@5ac2ae3ea1f311be61955b2d554e8510474cf4f0',
   'build/third_party/lighttpd':
     '/trunk/deps/third_party/lighttpd@58968',
   'src/buildtools':


### PR DESCRIPTION
Manually advance the ANGLE checkout one commit ahead in its
chromium/2062 to grab the fix its bug 669 ("Build started depending on
.git/").

This is required for a build from a tarball to work, and allows us to
remove our manual workaround from the Tizen packaging.

The roll upstream will be part of more recent M37 releases.
