### PR TITLE
M38 [Tizen][Temp] Move ScreenOrientationProvider::Create to cc file

### DIFF
--- a/content/browser/screen_orientation/screen_orientation_dispatcher_host.cc
+++ b/content/browser/screen_orientation/screen_orientation_dispatcher_host.cc
@@ -100,6 +100,11 @@ void ScreenOrientationDispatcherHost::OnOrientationChange() {
     provider_->OnOrientationChange();
 }
 
+void ScreenOrientationDispatcherHost::SetProvider(
+    ScreenOrientationProvider* provider) {
+  provider_.reset(provider);
+}
+
 void ScreenOrientationDispatcherHost::OnLockRequest(
     RenderFrameHost* render_frame_host,
     blink::WebScreenOrientationLockType orientation,

--- a/content/browser/screen_orientation/screen_orientation_dispatcher_host.h
+++ b/content/browser/screen_orientation/screen_orientation_dispatcher_host.h
@@ -43,6 +43,8 @@ class CONTENT_EXPORT ScreenOrientationDispatcherHost
 
   void OnOrientationChange();
 
+  void SetProvider(ScreenOrientationProvider* provider);
+
  private:
   void OnLockRequest(RenderFrameHost* render_frame_host,
                      blink::WebScreenOrientationLockType orientation,

--- a/content/browser/screen_orientation/screen_orientation_provider.cc
+++ b/content/browser/screen_orientation/screen_orientation_provider.cc
@@ -1,0 +1,18 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/browser/screen_orientation/screen_orientation_provider.h"
+
+namespace content {
+
+#if !defined(OS_ANDROID)
+// static
+ScreenOrientationProvider* ScreenOrientationProvider::Create(
+    ScreenOrientationDispatcherHost* dispatcher_host,
+    WebContents* web_contents) {
+  return NULL;
+}
+#endif // !defined(OS_ANDROID)
+
+}  // namespace content

--- a/content/browser/screen_orientation/screen_orientation_provider.h
+++ b/content/browser/screen_orientation/screen_orientation_provider.h
@@ -43,15 +43,6 @@ class ScreenOrientationProvider {
   DISALLOW_COPY_AND_ASSIGN(ScreenOrientationProvider);
 };
 
-#if !defined(OS_ANDROID)
-// static
-ScreenOrientationProvider* ScreenOrientationProvider::Create(
-    ScreenOrientationDispatcherHost* dispatcher_host,
-    WebContents* web_contents) {
-  return NULL;
-}
-#endif // !defined(OS_ANDROID)
-
 } // namespace content
 
 #endif // CONTENT_BROWSER_SCREEN_ORIENTATION_SCREEN_ORIENTATION_PROVIDER_H_

--- a/content/content_browser.gypi
+++ b/content/content_browser.gypi
@@ -1121,6 +1121,7 @@
       'browser/screen_orientation/screen_orientation_dispatcher_host.h',
       'browser/screen_orientation/screen_orientation_message_filter_android.h',
       'browser/screen_orientation/screen_orientation_message_filter_android.cc',
+      'browser/screen_orientation/screen_orientation_provider.cc',
       'browser/screen_orientation/screen_orientation_provider.h',
       'browser/screen_orientation/screen_orientation_provider_android.h',
       'browser/screen_orientation/screen_orientation_provider_android.cc',


### PR DESCRIPTION
This commit fixes ScreenOrientationProvider::Create() to be defined multiple
times error. Meanwhile, add ScreenOrientationDispatcherHost::SetProvider so that
tizen can use this inferface to bridge with ScreenOrientationDispatcherHost.

Upstream bug https://code.google.com/p/chromium/issues/detail?id=408573 to trace this problem.
Send https://codereview.chromium.org/513073002/ to solve it.

CL: https://codereview.chromium.org/338373002
