### PR TITLE
[Tizen] Make content fit to the viewport

### DIFF
--- a/content/renderer/render_view_impl.cc
+++ b/content/renderer/render_view_impl.cc
@@ -1138,6 +1138,8 @@ void RenderView::ApplyWebPreferences(const WebPreferences& prefs,
 
   // Enable double tap to zoom when zoomable.
   settings->setDoubleTapToZoomEnabled(true);
+
+  settings->setShrinksViewportContentToFit(true);
 #endif
 
 #if defined(OS_ANDROID)


### PR DESCRIPTION
This actually means that 'setShrinksViewportContentToFit'
setting should be set. This is necessary for viewport
meta tag enabling on Tizen.
