### PR TITLE
[Temp] Apply ozone-wayland's 0008-Fix-crash-when-switching-to-console-VT-mode.patch.

### DIFF
--- a/ui/gl/gl_context_egl.cc
+++ b/ui/gl/gl_context_egl.cc
@@ -112,6 +112,10 @@ bool GLContextEGL::MakeCurrent(GLSurface* surface) {
     return false;
   }
 
+#if defined(USE_OZONE)
+  eglSwapInterval(display_, 0);
+#endif
+
   // Set this as soon as the context is current, since we might call into GL.
   SetRealGLApi();
 


### PR DESCRIPTION
Original commit message:
  Fix crash when switching to console(VT) mode

  Buffer swapping should not be synchronized so that the GPU process
  is not blocked by waiting for a frame update from Weston.

  Bug: TC-341

It is not clear from ozone-wayland's pull request #300 if this change
has been submitted upstream.
