### PR TITLE
.gitignore: Ignore src/third_party/khronos/CL.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,6 +267,7 @@ v8.log
 /third_party/jarjar
 /third_party/jsoncpp/source
 /third_party/jsr-305/src
+/third_party/khronos/CL
 /third_party/leveldatabase/src
 /third_party/leveldb
 /third_party/libaddressinput/src


### PR DESCRIPTION
We started checking out this directory with Crosswalk PR#2426, but since
we do not have it in .gitignore the directory ends up being removed
every time we run gclient sync.
