### PR TITLE
.gitignore: Ignore src/third_party/webcl.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,6 +336,7 @@ v8.log
 /third_party/v8-i18n
 /third_party/valgrind
 /third_party/v4l2capture
+/third_party/webcl
 /third_party/webdriver/pylib
 /third_party/webdriver/python/selenium
 /third_party/webgl


### PR DESCRIPTION
We started checking out this directory with Crosswalk including the
webcl conformance test suite. So we should ignore this directory
to avoid being removed when gclient sync.
