### PR TITLE
[Android] Use SVN revision in LASTCHANGE.blink

### DIFF
--- a/build/util/lastchange.py
+++ b/build/util/lastchange.py
@@ -129,7 +129,8 @@ def FetchGitSVNURLAndRevision(directory, svn_url_regex):
   Returns:
     A tuple containing the Subversion URL and revision.
   """
-  proc = RunGitCommand(directory, ['log', '-1', '--format=%b'])
+  proc = RunGitCommand(directory, ['log', '-1',
+                                   '--grep=git-svn-id', '--format=%b'])
   if proc:
     output = proc.communicate()[0].strip()
     if proc.returncode == 0 and output:


### PR DESCRIPTION
The lastchange of blink repo will be used in remote
devtools url generating which only takes svn revision.

For crosswalk, it will have patches applied on blink.
Together with upstream change bdaef127, the LASTCHANGE.blink
will contain git hash id for crosswalk case.

Fix this by partly reverting bdaef127.
