### PR TITLE
[TIZEN] Set app ID and media class properties for the audio streams.

### DIFF
--- a/content/browser/renderer_host/media/audio_renderer_host.cc
+++ b/content/browser/renderer_host/media/audio_renderer_host.cc
@@ -65,6 +65,11 @@ class AudioRendererHost::AudioEntry
   bool playing() const { return playing_; }
   void set_playing(bool playing) { playing_ = playing; }
 
+#if defined(OS_TIZEN)
+  std::string app_id() const override { return host_->app_id_; }
+  std::string app_class() const override { return host_->app_class_; }
+#endif
+
  private:
   // media::AudioOutputController::EventHandler implementation.
   virtual void OnCreated() OVERRIDE;
@@ -483,5 +488,14 @@ AudioRendererHost::AudioEntry* AudioRendererHost::LookupById(int stream_id) {
 bool AudioRendererHost::HasActiveAudio() {
   return !base::AtomicRefCountIsZero(&num_playing_streams_);
 }
+
+#if defined(OS_TIZEN)
+void AudioRendererHost::SetMediaStreamProperties(
+    const std::string& app_id,
+    const std::string& app_class) {
+  app_id_ = app_id;
+  app_class_ = app_class;
+}
+#endif
 
 }  // namespace content

--- a/content/browser/renderer_host/media/audio_renderer_host.h
+++ b/content/browser/renderer_host/media/audio_renderer_host.h
@@ -38,6 +38,9 @@
 #define CONTENT_BROWSER_RENDERER_HOST_MEDIA_AUDIO_RENDERER_HOST_H_
 
 #include <map>
+#if defined(OS_TIZEN)
+#include <string>
+#endif
 
 #include "base/atomic_ref_count.h"
 #include "base/gtest_prod_util.h"
@@ -88,6 +91,15 @@ class CONTENT_EXPORT AudioRendererHost : public BrowserMessageFilter {
   // Returns true if any streams managed by this host are actively playing.  Can
   // be called from any thread.
   bool HasActiveAudio();
+
+#if defined(OS_TIZEN)
+  // Sets an application ID and class properties, which are used to tag audio
+  // streams in pulseaudio/Murphy.
+  virtual void SetMediaStreamProperties(const std::string& app_id,
+                                        const std::string& app_class);
+  const std::string& app_id() const { return app_id_; }
+  const std::string& app_class() const { return app_class_; }
+#endif
 
  private:
   friend class AudioRendererHostTest;
@@ -172,6 +184,12 @@ class CONTENT_EXPORT AudioRendererHost : public BrowserMessageFilter {
 
   // The number of streams in the playing state.
   base::AtomicRefCount num_playing_streams_;
+
+#if defined(OS_TIZEN)
+  // Application ID and class for the Murphy resource set.
+  std::string app_id_;
+  std::string app_class_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(AudioRendererHost);
 };

--- a/media/audio/audio_io.h
+++ b/media/audio/audio_io.h
@@ -5,6 +5,10 @@
 #ifndef MEDIA_AUDIO_AUDIO_IO_H_
 #define MEDIA_AUDIO_AUDIO_IO_H_
 
+#if defined(OS_TIZEN)
+#include <string>
+#endif
+
 #include "base/basictypes.h"
 #include "media/audio/audio_buffers_state.h"
 #include "media/base/audio_bus.h"
@@ -99,6 +103,13 @@ class MEDIA_EXPORT AudioOutputStream {
   // Close the stream. This also generates AudioSourceCallback::OnClose().
   // After calling this method, the object should not be used anymore.
   virtual void Close() = 0;
+
+#if defined(OS_TIZEN)
+  // Sets an application ID and class properties, which are used to tag audio
+  // streams in pulseaudio/Murphy.
+  virtual void SetMediaStreamProperties(const std::string& app_id,
+                                        const std::string& app_class) {}
+#endif
 };
 
 // Models an audio sink receiving recorded audio from the audio driver.

--- a/media/audio/audio_output_controller.cc
+++ b/media/audio/audio_output_controller.cc
@@ -127,6 +127,10 @@ void AudioOutputController::DoCreate(bool is_for_device_change) {
     return;
   }
 
+#if defined(OS_TIZEN)
+  stream_->SetMediaStreamProperties(handler_->app_id(), handler_->app_class());
+#endif
+
   if (!stream_->Open()) {
     DoStopCloseAndClearStream();
     state_ = kError;

--- a/media/audio/audio_output_controller.h
+++ b/media/audio/audio_output_controller.h
@@ -5,6 +5,10 @@
 #ifndef MEDIA_AUDIO_AUDIO_OUTPUT_CONTROLLER_H_
 #define MEDIA_AUDIO_AUDIO_OUTPUT_CONTROLLER_H_
 
+#if defined(OS_TIZEN)
+#include <string>
+#endif
+
 #include "base/atomic_ref_count.h"
 #include "base/callback.h"
 #include "base/memory/ref_counted.h"
@@ -68,6 +72,11 @@ class MEDIA_EXPORT AudioOutputController
     virtual void OnPaused() = 0;
     virtual void OnError() = 0;
     virtual void OnDeviceChange(int new_buffer_size, int new_sample_rate) = 0;
+
+#if defined(OS_TIZEN)
+    virtual std::string app_id() const = 0;
+    virtual std::string app_class() const = 0;
+#endif
 
    protected:
     virtual ~EventHandler() {}

--- a/media/audio/audio_output_dispatcher.cc
+++ b/media/audio/audio_output_dispatcher.cc
@@ -25,4 +25,13 @@ AudioOutputDispatcher::~AudioOutputDispatcher() {
   DCHECK(task_runner_->BelongsToCurrentThread());
 }
 
+#if defined(OS_TIZEN)
+void AudioOutputDispatcher::SetMediaStreamProperties(
+    const std::string& app_id,
+    const std::string& app_class) {
+  app_id_ = app_id;
+  app_class_ = app_class;
+}
+#endif
+
 }  // namespace media

--- a/media/audio/audio_output_dispatcher.h
+++ b/media/audio/audio_output_dispatcher.h
@@ -18,6 +18,10 @@
 #ifndef MEDIA_AUDIO_AUDIO_OUTPUT_DISPATCHER_H_
 #define MEDIA_AUDIO_AUDIO_OUTPUT_DISPATCHER_H_
 
+#if defined(OS_TIZEN)
+#include <string>
+#endif
+
 #include "base/basictypes.h"
 #include "base/memory/ref_counted.h"
 #include "base/timer/timer.h"
@@ -67,6 +71,11 @@ class MEDIA_EXPORT AudioOutputDispatcher
 
   const std::string& device_id() const { return device_id_; }
 
+#if defined(OS_TIZEN)
+  virtual void SetMediaStreamProperties(const std::string& app_id,
+                                        const std::string& app_class);
+#endif
+
  protected:
   friend class base::RefCountedThreadSafe<AudioOutputDispatcher>;
   virtual ~AudioOutputDispatcher();
@@ -77,6 +86,11 @@ class MEDIA_EXPORT AudioOutputDispatcher
   const scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
   const AudioParameters params_;
   std::string device_id_;
+
+#if defined(OS_TIZEN)
+  std::string app_id_;
+  std::string app_class_;
+#endif
 
  private:
   DISALLOW_COPY_AND_ASSIGN(AudioOutputDispatcher);

--- a/media/audio/audio_output_dispatcher_impl.cc
+++ b/media/audio/audio_output_dispatcher_impl.cc
@@ -137,6 +137,10 @@ bool AudioOutputDispatcherImpl::CreateAndOpenStream() {
   if (!stream)
     return false;
 
+#if defined(OS_TIZEN)
+  stream->SetMediaStreamProperties(app_id_, app_class_);
+#endif
+
   if (!stream->Open()) {
     stream->Close();
     return false;

--- a/media/audio/audio_output_proxy.cc
+++ b/media/audio/audio_output_proxy.cc
@@ -90,4 +90,11 @@ void AudioOutputProxy::Close() {
   delete this;
 }
 
+#if defined(OS_TIZEN)
+void AudioOutputProxy::SetMediaStreamProperties(const std::string& app_id,
+                                                const std::string& app_class) {
+  dispatcher_->SetMediaStreamProperties(app_id, app_class);
+}
+#endif
+
 }  // namespace media

--- a/media/audio/audio_output_proxy.h
+++ b/media/audio/audio_output_proxy.h
@@ -5,6 +5,10 @@
 #ifndef MEDIA_AUDIO_AUDIO_OUTPUT_PROXY_H_
 #define MEDIA_AUDIO_AUDIO_OUTPUT_PROXY_H_
 
+#if defined(OS_TIZEN)
+#include <string>
+#endif
+
 #include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "base/memory/ref_counted.h"
@@ -38,6 +42,11 @@ class MEDIA_EXPORT AudioOutputProxy
   virtual void SetVolume(double volume) OVERRIDE;
   virtual void GetVolume(double* volume) OVERRIDE;
   virtual void Close() OVERRIDE;
+
+#if defined(OS_TIZEN)
+  void SetMediaStreamProperties(const std::string& app_id,
+                                const std::string& app_class) override;
+#endif
 
  private:
   enum State {

--- a/media/audio/audio_output_resampler.cc
+++ b/media/audio/audio_output_resampler.cc
@@ -178,6 +178,10 @@ void AudioOutputResampler::Initialize() {
 bool AudioOutputResampler::OpenStream() {
   DCHECK(task_runner_->BelongsToCurrentThread());
 
+#if defined(OS_TIZEN)
+  dispatcher_->SetMediaStreamProperties(app_id_, app_class_);
+#endif
+
   if (dispatcher_->OpenStream()) {
     // Only record the UMA statistic if we didn't fallback during construction
     // and only for the first stream we open.
@@ -245,6 +249,10 @@ bool AudioOutputResampler::StartStream(
   } else {
     resampler_callback = it->second;
   }
+
+#if defined(OS_TIZEN)
+  dispatcher_->SetMediaStreamProperties(app_id_, app_class_);
+#endif
 
   resampler_callback->Start(callback);
   bool result = dispatcher_->StartStream(resampler_callback, stream_proxy);

--- a/media/audio/pulse/pulse.sigs
+++ b/media/audio/pulse/pulse.sigs
@@ -50,3 +50,8 @@ void pa_stream_unref(pa_stream* s);
 int pa_context_errno(pa_context *c);
 const char* pa_strerror(int error);
 pa_cvolume* pa_cvolume_set(pa_cvolume* a, unsigned  channels, pa_volume_t v);
+# Functions from pulse used in TIZEN to set the audio stream role.
+pa_proplist* pa_proplist_new(void);
+void pa_proplist_free(pa_proplist* p);
+int pa_proplist_sets(pa_proplist *p, const char *key, const char *value);
+pa_stream* pa_stream_new_with_proplist(pa_context* c, const char* name, const pa_sample_spec* ss, const pa_channel_map* map, pa_proplist* proplist);

--- a/media/audio/pulse/pulse_output.cc
+++ b/media/audio/pulse/pulse_output.cc
@@ -234,4 +234,13 @@ void PulseAudioOutputStream::GetVolume(double* volume) {
   *volume = volume_;
 }
 
+#if defined(OS_TIZEN)
+void PulseAudioOutputStream::SetMediaStreamProperties(
+    const std::string& app_id,
+    const std::string& app_class) {
+  app_id_ = app_id;
+  app_class_ = app_class;
+}
+#endif
+
 }  // namespace media

--- a/media/audio/pulse/pulse_output.h
+++ b/media/audio/pulse/pulse_output.h
@@ -51,6 +51,13 @@ class PulseAudioOutputStream : public AudioOutputStream {
   virtual void SetVolume(double volume) OVERRIDE;
   virtual void GetVolume(double* volume) OVERRIDE;
 
+#if defined(OS_TIZEN)
+  void SetMediaStreamProperties(const std::string& app_id,
+                                const std::string& app_class) override;
+  const std::string& app_id() const {return app_id_;}
+  const std::string& app_class() const {return app_class_;}
+#endif
+
  private:
   // Called by PulseAudio when |pa_stream_| change state.  If an unexpected
   // failure state change happens and |source_callback_| is set
@@ -90,6 +97,12 @@ class PulseAudioOutputStream : public AudioOutputStream {
 
   // Container for retrieving data from AudioSourceCallback::OnMoreData().
   scoped_ptr<AudioBus> audio_bus_;
+
+#if defined(OS_TIZEN)
+  // Application ID and class for the pulseaudio streams.
+  std::string app_id_;
+  std::string app_class_;
+#endif
 
   base::ThreadChecker thread_checker_;
 

--- a/media/audio/pulse/pulse_util.cc
+++ b/media/audio/pulse/pulse_util.cc
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#if defined(OS_TIZEN)
+#include "media/audio/pulse/pulse_output.h"
+#endif
+
 #include "media/audio/pulse/pulse_util.h"
 
 #include "base/logging.h"
@@ -259,7 +263,20 @@ bool CreateOutputStream(pa_threaded_mainloop** mainloop,
     // than the default channel map (NULL).
     map = &source_channel_map;
   }
+
+#if defined(OS_TIZEN)
+  PulseAudioOutputStream* data =
+      static_cast<PulseAudioOutputStream*>(user_data);
+  pa_proplist* proplist = pa_proplist_new();
+  pa_proplist_sets(proplist, "resource.set.appid", data->app_id().c_str());
+  pa_proplist_sets(proplist, PA_PROP_MEDIA_ROLE, data->app_class().c_str());
+  *stream = pa_stream_new_with_proplist(*context, "Playback",
+                                        &sample_specifications,
+                                        map, proplist);
+  pa_proplist_free(proplist);
+#else
   *stream = pa_stream_new(*context, "Playback", &sample_specifications, map);
+#endif
   RETURN_ON_FAILURE(*stream, "failed to create PA playback stream");
 
   pa_stream_set_state_callback(*stream, stream_callback, user_data);


### PR DESCRIPTION
Add an interface to set application ID and media class properties for the audio streams in
pulseaudio and Murhy, so that the Murphy resource policy daemon can dictate when the
audio will be paused and resumed in response to other audio playing.

BUG=XWALK-2788
