### PR TITLE
Turn of xslt in webkit preferences

### DIFF
--- a/content/public/common/web_preferences.cc
+++ b/content/public/common/web_preferences.cc
@@ -60,7 +60,11 @@ WebPreferences::WebPreferences()
       allow_scripts_to_close_windows(false),
       remote_fonts_enabled(true),
       javascript_can_access_clipboard(false),
+#if defined(DISABLE_XSLT)
+      xslt_enabled(false),
+#else
       xslt_enabled(true),
+#endif
       xss_auditor_enabled(true),
       dns_prefetching_enabled(true),
       local_storage_enabled(false),


### PR DESCRIPTION
The preferences will not work any more if disable_xslt
specified. But leave it unchanged is confusing.
