### PR TITLE
Revert Tizen changes to support changing the system location provider.

### DIFF
--- a/content/browser/geolocation/location_arbitrator_impl.cc
+++ b/content/browser/geolocation/location_arbitrator_impl.cc
@@ -149,7 +149,7 @@ LocationProvider* LocationArbitratorImpl::NewNetworkLocationProvider(
     net::URLRequestContextGetter* context,
     const GURL& url,
     const base::string16& access_token) {
-#if defined(OS_ANDROID) || defined(OS_TIZEN)
+#if defined(OS_ANDROID)
   // Android uses its own SystemLocationProvider.
   return NULL;
 #else
@@ -159,9 +159,7 @@ LocationProvider* LocationArbitratorImpl::NewNetworkLocationProvider(
 }
 
 LocationProvider* LocationArbitratorImpl::NewSystemLocationProvider() {
-#if defined(OS_TIZEN)
-  return content::NewSystemLocationProvider();
-#elif defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
   return NULL;
 #else
   return content::NewSystemLocationProvider();


### PR DESCRIPTION
This reverts the following commits:
- 9132a4f "[Tizen] Enable geolocation for Tizen"
- 801bdbf "[Tizen] Use Tizen system location provider for geolocation subsystem"

They have not been needed since at least M35(!), when Chromium commit
5038bce99 ("location: Refactor LocationProvider") made it possible to
change the system location provider in ContentBrowserClient.

We can now do everything on the Crosswalk side, and also fixes an issue
with building Crosswalk for Tizen with `-Dcomponent=shared_library`, as
libcontent.so would not have an implementation of
`content::NewSystemLocationProvider()` (this did not happen before the
content layer was being built as a static library linked into the
Crosswalk binary that had an implementation for that symbol).
