### PR TITLE
Fix GPU process crash

### DIFF
--- a/content/common/sandbox_linux/bpf_gpu_policy_linux.cc
+++ b/content/common/sandbox_linux/bpf_gpu_policy_linux.cc
@@ -226,9 +226,7 @@ bool GpuProcessPolicy::PreSandboxHook() {
 
 #if defined(OS_TIZEN)
       if (IsArchitectureX86_64()) {
-        // TODO(halton): Add 64-bit VA driver when 64-bit Tizen support
-        // is ready.
-        return false;
+        I965DrvVideoPath = "/usr/lib64/dri/i965_dri.so";
       } else if (IsArchitectureI386()) {
         I965DrvVideoPath = "/usr/lib/dri/i965_dri.so";
       }


### PR DESCRIPTION
Fix GPU process crash on "Check failed: policy->PreSandboxHook()".

Related to: XWALK-2789
