### PR TITLE
[Extensions] Build glib message pump on Ozone by default

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -1385,7 +1385,7 @@ test("base_unittests") {
     configs += [ "//build/config/linux:glib" ]
   }
 
-  if (!is_linux || use_ozone) {
+  if (!is_linux) {
     sources -= [ "message_loop/message_pump_glib_unittest.cc" ]
   }
 

--- a/base/base.gyp
+++ b/base/base.gyp
@@ -54,7 +54,7 @@
               ['exclude', '_nss\\.cc$'],
             ],
         }],
-        ['use_glib==1 or <(use_ozone)==1', {
+        ['use_glib==1', {
           'dependencies': [
             '../build/linux/system.gyp:glib',
           ],
@@ -737,11 +737,6 @@
             '../build/linux/system.gyp:glib',
           ],
         }, {  # use_glib == 0
-          'sources!': [
-            'message_loop/message_pump_glib_unittest.cc',
-          ]
-        }],
-        ['use_ozone == 1', {
           'sources!': [
             'message_loop/message_pump_glib_unittest.cc',
           ]

--- a/base/base.gypi
+++ b/base/base.gypi
@@ -752,7 +752,7 @@
                 'atomicops_internals_x86_gcc.cc',
               ],
           }],
-          ['(<(use_glib)==0 and <(use_ozone)==0) or >(nacl_untrusted_build)==1', {
+          ['<(use_glib)==0 or >(nacl_untrusted_build)==1', {
               'sources!': [
                 'message_loop/message_pump_glib.cc',
               ],

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -703,7 +703,7 @@
         }],
 
         # Flags to use glib.
-        ['OS=="win" or OS=="mac" or OS=="ios" or OS=="android" or use_ozone==1', {
+        ['OS=="win" or OS=="mac" or OS=="ios" or OS=="android"', {
           'use_glib%': 0,
         }, {
           'use_glib%': 1,


### PR DESCRIPTION
Use glib main loop when building Ozone (not only for the
extension process). This will make glib based external
extensions work when disabling the extension process.

TODO: squash this patch with the two others of the same kind.