### PR TITLE
[Temp] Export ui::NativeDisplayDelegateOzone.

### DIFF
--- a/ui/ozone/common/native_display_delegate_ozone.h
+++ b/ui/ozone/common/native_display_delegate_ozone.h
@@ -7,10 +7,11 @@
 
 #include "base/macros.h"
 #include "ui/display/types/native_display_delegate.h"
+#include "ui/ozone/ozone_export.h"
 
 namespace ui {
 
-class NativeDisplayDelegateOzone : public NativeDisplayDelegate {
+class OZONE_EXPORT NativeDisplayDelegateOzone : public NativeDisplayDelegate {
  public:
   NativeDisplayDelegateOzone();
   ~NativeDisplayDelegateOzone() override;


### PR DESCRIPTION
This class is used by ozone-wayland, but building Crosswalk with
`-Dcomponent=shared_library` causes linking to fail because this symbol is
not exported by libozone.so even though it is referenced in
libwayland.so.

The best approach upstream is still being discussed, including using a
different class in ozone-wayland. For now, we need it for XWALK-2571, as
building Crosswalk in shared library mode is part of the solution for
it.