### PR TITLE
[Temp] Make unix socket Get{Peer|Local}Address return more rational erro...

### DIFF
--- a/net/socket/unix_domain_client_socket_posix.cc
+++ b/net/socket/unix_domain_client_socket_posix.cc
@@ -9,6 +9,7 @@
 
 #include "base/logging.h"
 #include "base/posix/eintr_wrapper.h"
+#include "net/base/ip_endpoint.h"
 #include "net/base/net_errors.h"
 #include "net/base/net_util.h"
 #include "net/socket/socket_libevent.h"
@@ -98,13 +99,25 @@ bool UnixDomainClientSocket::IsConnectedAndIdle() const {
 }
 
 int UnixDomainClientSocket::GetPeerAddress(IPEndPoint* address) const {
-  NOTIMPLEMENTED();
-  return ERR_NOT_IMPLEMENTED;
+  // Unix domain sockets have no valid associated addr/port;
+  // return either not connected or address invalid.
+  DCHECK(address);
+
+  if (!IsConnected())
+    return ERR_SOCKET_NOT_CONNECTED;
+
+  return ERR_ADDRESS_INVALID;
 }
 
 int UnixDomainClientSocket::GetLocalAddress(IPEndPoint* address) const {
-  NOTIMPLEMENTED();
-  return ERR_NOT_IMPLEMENTED;
+  // Unix domain sockets have no valid associated addr/port;
+  // return either not connected or address invalid.
+  DCHECK(address);
+
+  if (!socket_)
+    return ERR_SOCKET_NOT_CONNECTED;
+
+  return ERR_ADDRESS_INVALID;
 }
 
 const BoundNetLog& UnixDomainClientSocket::NetLog() const {


### PR DESCRIPTION
...rs.

Rather than return ERR_NOT_IMPLEMENTED it seems sensible to
return ERR_SOCKET_NOT_CONNECTED in the case that the socket
is not connected, but unconditionally return ERR_ADDRESS_INVALID
if connected (because there's no IP addr or port associated
with either end of the socket).

BUG=431412

Review URL: https://codereview.chromium.org/841993002

Cr-Commit-Position: refs/heads/master@{#310564}