### PR TITLE
[Android] Backport some upstream commits to fix our device tests.

### DIFF
--- a/build/android/pylib/android_commands.py
+++ b/build/android/pylib/android_commands.py
@@ -696,8 +696,8 @@ class AndroidCommands(object):
         assert os.path.exists(run_pie_dist_path), 'Please build run_pie'
         # The PIE loader must be pushed manually (i.e. no PushIfNeeded) because
         # PushIfNeeded requires md5sum and md5sum requires the wrapper as well.
-        command = 'push %s %s' % (run_pie_dist_path, PIE_WRAPPER_PATH)
-        assert _HasAdbPushSucceeded(self._adb.SendCommand(command))
+        adb_command = 'push %s %s' % (run_pie_dist_path, PIE_WRAPPER_PATH)
+        assert _HasAdbPushSucceeded(self._adb.SendCommand(adb_command))
         self._pie_wrapper = PIE_WRAPPER_PATH
 
     if self._pie_wrapper:

--- a/build/android/pylib/device/device_utils.py
+++ b/build/android/pylib/device/device_utils.py
@@ -820,7 +820,7 @@ class DeviceUtils(object):
         self.RunShellCommand(
             ['unzip', zip_on_device],
             as_root=True,
-            env={'PATH': '$PATH:%s' % install_commands.BIN_DIR},
+            env={'PATH': '%s:$PATH' % install_commands.BIN_DIR},
             check_return=True)
       finally:
         if zip_proc.is_alive():

--- a/build/android/pylib/device/device_utils_test.py
+++ b/build/android/pylib/device/device_utils_test.py
@@ -995,7 +995,7 @@ class DeviceUtilsPushChangedFilesZippedTest(DeviceUtilsNewImplTest):
         self.call.device.RunShellCommand(
             ['unzip', '/test/device/external_dir/tmp.zip'],
             as_root=True,
-            env={'PATH': '$PATH:/data/local/tmp/bin'},
+            env={'PATH': '/data/local/tmp/bin:$PATH'},
             check_return=True),
         (self.call.device.IsOnline(), True),
         self.call.device.RunShellCommand(


### PR DESCRIPTION
There have been some changes in M41 that causes our device tests to fail on the ICS devices we have. This pull request backports some fixes I made upstream for them so that we get back to a usable state.

We still upload some binaries (like `device_forwarder`) to the device more often than we actually need (see [this Chromium bug I reported](https://code.google.com/p/chromium/issues/detail?id=458658) for more information), but it is nothing too huge.