### PR TITLE
Revert @viewport enabling patches

### DIFF
--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -189,9 +189,6 @@ void SetRuntimeFeaturesDefaultsAndUpdateFromArgs(
   if (command_line.HasSwitch(switches::kEnableCredentialManagerAPI))
     WebRuntimeFeatures::enableCredentialManagerAPI(true);
 
-  if (command_line.HasSwitch(switches::kEnableViewport))
-    WebRuntimeFeatures::enableCSSViewport(true);
-
   if (command_line.HasSwitch(switches::kDisableSVG1DOM)) {
     WebRuntimeFeatures::enableSVG1DOM(false);
   }


### PR DESCRIPTION
This CL reverts

https://codereview.chromium.org/669673003 Use the "enableCSSViewport" method to enable CSS viewport feature

and

https://codereview.chromium.org/633943002 Fix the "--enable-viewport" command line option

BUG=432813

Review URL: https://codereview.chromium.org/791123003

Cr-Commit-Position: refs/heads/master@{#307815}
(cherry picked from commit 602289d4c714b77a44fd8694915b05650259012d)

BUG=XWALK-3574