### PR TITLE
[Android] Allow constructor of Notifications on Android.

### DIFF
--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -62,9 +62,6 @@ static void SetRuntimeFeatureDefaultsForPlatform() {
   // the feature via experimental web platform features.
   if (base::FieldTrialList::FindFullName("NavigationTransitions") == "Enabled")
     WebRuntimeFeatures::enableNavigationTransitions(true);
-  // Android won't be able to reliably support non-persistent notifications, the
-  // intended behavior for which is in flux by itself.
-  WebRuntimeFeatures::enableNotificationConstructor(false);
 #else
   WebRuntimeFeatures::enableNavigatorContentUtils(true);
 #endif  // defined(OS_ANDROID)


### PR DESCRIPTION
We support notifications in Android but upstream doesn't so we
should make sure they are enabled.

We should really consider if the "desktop" notifications are the way
forward for us in Android now that we have ServiceWorker and
push notifications.

https://codereview.chromium.org/920153002

BUG=XWALK-3653