### PR TITLE
[Backport] Put ChannelMojo initialization before starting in-process-render-thread

### DIFF
--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -620,11 +620,17 @@ bool RenderProcessHostImpl::Init() {
     // in-process plugins.
     options.message_loop_type = base::MessageLoop::TYPE_DEFAULT;
 #endif
+
+    // As for execution sequence, this callback should have no any dependency
+    // on starting in-process-render-thread.
+    // So put it here to trigger ChannelMojo initialization earlier to enable
+    // in-process-render-thread using ChannelMojo there.
+    OnProcessLaunched();  // Fake a callback that the process is ready.
+
     in_process_renderer_->StartWithOptions(options);
 
     g_in_process_thread = in_process_renderer_->message_loop();
 
-    OnProcessLaunched();  // Fake a callback that the process is ready.
   } else {
     // Build command line for renderer.  We call AppendRendererCommandLine()
     // first so the process type argument will appear first.


### PR DESCRIPTION

ChannelMojo between Browser&Render will be established after
started InProcessRendererThread, this would make some differences
with before(or ChannelMojo disabled case). Actually it would forbid
sending SyncMessage from InProcessRendererThread::Init(), which is enabled before.

BUG=466925
TBR=morrita@chromium.org,rjkroege@chromium.org

Review URL: https://codereview.chromium.org/1003123002

Cr-Commit-Position: refs/heads/master@{#320586}