### PR TITLE
[Backport] Revert of Enable ChannelMojo (patchset #3 id:40001 of https:/...

### DIFF
--- a/ipc/mojo/ipc_channel_mojo.cc
+++ b/ipc/mojo/ipc_channel_mojo.cc
@@ -187,8 +187,8 @@ void ChannelMojo::ChannelInfoDeleter::operator()(
 
 // static
 bool ChannelMojo::ShouldBeUsed() {
-  // TODO(morrita): Remove this if it sticks.
-  return true;
+  // TODO(morrita): Turn this on for a set of platforms.
+  return false;
 }
 
 // static


### PR DESCRIPTION
.../codereview.chromium.org/857483004/)

Reason for revert:
This is breaking a lot of things (He's dead jim pages, extensions, and other things). See issue 462026.

Original issue's description:
> Enable ChannelMojo
>
> As we addressed certain amount of the performance problem,
> it's time to give it another try.
>
> R=viettrungluu@chromium.org
> BUG=377980
>
> Committed: https://crrev.com/a06cd1b2fe83b51b0874ca504066f00a17192026
> Cr-Commit-Position: refs/heads/master@{#313184}

TBR=viettrungluu@chromium.org,morrita@chromium.org
NOPRESUBMIT=true
NOTREECHECKS=true
NOTRY=true
BUG=377980

Review URL: https://codereview.chromium.org/1002973002

Cr-Commit-Position: refs/heads/master@{#320394}