### PR TITLE
[Android] Enable support for notifications on ICS devices.

### DIFF
--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -73,7 +73,7 @@ void SetContentCommandLineFlags(bool single_process,
 
   // Web Notifications are only supported on Android JellyBean and beyond.
   if (base::android::BuildInfo::GetInstance()->sdk_int() <
-      base::android::SDK_VERSION_JELLY_BEAN) {
+      base::android::SDK_VERSION_ICE_CREAM_SANDWICH) {
     parsed_command_line->AppendSwitch(switches::kDisableNotifications);
   }
 


### PR DESCRIPTION
Upstream recently enabled support for notifications and Push API on
Android >= Jelly Bean (see commit d948e026, "Exceptions for enabling Web
Notifications and the Push API by default").

Our support for notifications in Crosswalk is currently simpler (more
similar to desktop-style notifications) and works on ICS devices as
well, so we can be more lax about which devices we actually support.

Related to: XWALK-3654