### PR TITLE
Add the command line option to load proprietary codec library.

### DIFF
--- a/content/browser/zygote_host/zygote_host_impl_linux.cc
+++ b/content/browser/zygote_host/zygote_host_impl_linux.cc
@@ -137,6 +137,7 @@ void ZygoteHostImpl::Init(const std::string& sandbox_cmd) {
     switches::kLoggingLevel,
     switches::kNoSandbox,
     switches::kPpapiInProcess,
+    switches::kProprietaryCodecLibPath,
     switches::kRegisterPepperPlugins,
     switches::kV,
     switches::kVModule,

--- a/content/public/common/content_switches.cc
+++ b/content/public/common/content_switches.cc
@@ -986,6 +986,10 @@ const char kEnableNpapi[]                   = "enable-npapi";
 const char kEnablePluginPowerSaver[] = "enable-plugin-power-saver";
 #endif
 
+#if defined(OS_LINUX)
+const char kProprietaryCodecLibPath[] = "proprietary-codec-lib-path";
+#endif
+
 // Don't dump stuff here, follow the same order as the header.
 
 }  // namespace switches

--- a/content/public/common/content_switches.h
+++ b/content/public/common/content_switches.h
@@ -299,6 +299,10 @@ CONTENT_EXPORT extern const char kEnableNpapi[];
 CONTENT_EXPORT extern const char kEnablePluginPowerSaver[];
 #endif
 
+#if defined(OS_LINUX)
+CONTENT_EXPORT extern const char kProprietaryCodecLibPath[];
+#endif
+
 // DON'T ADD RANDOM STUFF HERE. Put it in the main section above in
 // alphabetical order, or in one of the ifdefs (also in order in each section).
 


### PR DESCRIPTION
Due to licensing issues, the pre-built binary doesn't ship with the
necessary codecs for patented media formats. Therefore, mp4/mp3 files
can't be played back by Crosswalk.

Add a command line option so that mp4/mp3 files can be played by loading
the proprietary library. An example is,
xwalk --proprietary-codec-lib-path=/opt/google/chrome/libffmpegsumo.so