### PR TITLE
Add flag to diable hrtf in webaudio

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -553,6 +553,9 @@
       # Enable FTP support by default.
       'disable_ftp_support%': 0,
 
+      # Enable web audio hrtf by default.
+      'disable_webaudio_hrtf%': 0,
+
       # Use native android functions in place of ICU.  Not supported by most
       # components.
       'use_icu_alternatives_on_android%': 0,
@@ -1202,6 +1205,7 @@
     'enable_captive_portal_detection%': '<(enable_captive_portal_detection)',
     'disable_file_support%': '<(disable_file_support)',
     'disable_ftp_support%': '<(disable_ftp_support)',
+    'disable_webaudio_hrtf%': '<(disable_webaudio_hrtf)',
     'use_icu_alternatives_on_android%': '<(use_icu_alternatives_on_android)',
     'enable_task_manager%': '<(enable_task_manager)',
     'sas_dll_path%': '<(sas_dll_path)',
@@ -2139,6 +2143,9 @@
       }],
       ['use_concatenated_impulse_responses==1', {
         'grit_defines': ['-D', 'use_concatenated_impulse_responses'],
+      }],
+      ['disable_webaudio_hrtf==1', {
+        'grit_defines': ['-D', 'disable_webaudio_hrtf'],
       }],
       ['enable_media_router==1', {
         'grit_defines': ['-D', 'enable_media_router'],


### PR DESCRIPTION
The code in blink project will use the flag disable_webaudio_hrtf to reduce the binary size.

This patch is backported from the crosswalk-lite branch.