### PR TITLE
localStorage: Aggressively flush to disk for Android WebView.

### DIFF
--- a/android_webview/lib/main/aw_main_delegate.cc
+++ b/android_webview/lib/main/aw_main_delegate.cc
@@ -94,6 +94,11 @@ bool AwMainDelegate::BasicStartupComplete(int* exit_code) {
   // WebView does not yet support screen orientation locking.
   cl->AppendSwitch(switches::kDisableScreenOrientationLock);
 
+  // WebView does not (yet) save Chromium data during shutdown, so add setting
+  // for Chrome to aggressively persist DOM Storage to minimize data loss.
+  // http://crbug.com/479767
+  cl->AppendSwitch(switches::kEnableAggressiveDOMStorageFlushing);
+
   // This is needed to be able to mmap the V8 snapshot and ICU data file
   // directly from the WebView .apk.
   // This needs to be here so that it gets to run before the code in

--- a/content/browser/browser_main_loop.cc
+++ b/content/browser/browser_main_loop.cc
@@ -23,6 +23,7 @@
 #include "base/trace_event/trace_event.h"
 #include "content/browser/browser_thread_impl.h"
 #include "content/browser/device_sensors/device_inertial_sensor_service.h"
+#include "content/browser/dom_storage/dom_storage_area.h"
 #include "content/browser/download/save_file_manager.h"
 #include "content/browser/gamepad/gamepad_service.h"
 #include "content/browser/gpu/browser_gpu_channel_host_factory.h"
@@ -576,6 +577,13 @@ void BrowserMainLoop::MainMessageLoopStart() {
     TRACE_EVENT0("startup", "BrowserMainLoop::Subsystem:MemoryObserver");
     memory_observer_.reset(new MemoryObserver());
     base::MessageLoop::current()->AddTaskObserver(memory_observer_.get());
+  }
+
+  if (parsed_command_line_.HasSwitch(
+          switches::kEnableAggressiveDOMStorageFlushing)) {
+    TRACE_EVENT0("startup",
+                 "BrowserMainLoop::Subsystem:EnableAggressiveCommitDelay");
+    DOMStorageArea::EnableAggressiveCommitDelay();
   }
 
 #if defined(TCMALLOC_TRACE_MEMORY_SUPPORTED)

--- a/content/browser/dom_storage/dom_storage_area.cc
+++ b/content/browser/dom_storage/dom_storage_area.cc
@@ -41,6 +41,8 @@ const int kMaxCommitsPerHour = 6;
 
 }  // namespace
 
+bool DOMStorageArea::s_aggressive_flushing_enabled_ = false;
+
 DOMStorageArea::RateLimiter::RateLimiter(size_t desired_rate,
                                          base::TimeDelta time_quantum)
     : rate_(desired_rate), samples_(0), time_quantum_(time_quantum) {
@@ -87,6 +89,10 @@ GURL DOMStorageArea::OriginFromDatabaseFileName(const base::FilePath& name) {
   std::string origin_id =
       name.BaseName().RemoveExtension().MaybeAsASCII();
   return storage::GetOriginFromIdentifier(origin_id);
+}
+
+void DOMStorageArea::EnableAggressiveCommitDelay() {
+  s_aggressive_flushing_enabled_ = true;
 }
 
 DOMStorageArea::DOMStorageArea(const GURL& origin,
@@ -378,6 +384,9 @@ DOMStorageArea::CommitBatch* DOMStorageArea::CreateCommitBatchIfNeeded() {
 }
 
 base::TimeDelta DOMStorageArea::ComputeCommitDelay() const {
+  if (s_aggressive_flushing_enabled_)
+    return base::TimeDelta::FromSeconds(1);
+
   base::TimeDelta elapsed_time = base::TimeTicks::Now() - start_time_;
   base::TimeDelta delay = std::max(
       base::TimeDelta::FromSeconds(kCommitDefaultDelaySecs),

--- a/content/browser/dom_storage/dom_storage_area.h
+++ b/content/browser/dom_storage/dom_storage_area.h
@@ -35,6 +35,12 @@ class CONTENT_EXPORT DOMStorageArea
   static base::FilePath DatabaseFileNameFromOrigin(const GURL& origin);
   static GURL OriginFromDatabaseFileName(const base::FilePath& file_name);
 
+  // Commence aggressive flushing. This should be called early in the startup -
+  // before any localStorage writing. Currently scheduled writes will not be
+  // rescheduled and will be flushed at the scheduled time after which
+  // aggressive flushing will commence.
+  static void EnableAggressiveCommitDelay();
+
   // Local storage. Backed on disk if directory is nonempty.
   DOMStorageArea(const GURL& origin,
                  const base::FilePath& directory,
@@ -151,6 +157,8 @@ class CONTENT_EXPORT DOMStorageArea
   base::TimeDelta ComputeCommitDelay() const;
 
   void ShutdownInCommitSequence();
+
+  static bool s_aggressive_flushing_enabled_;
 
   int64 namespace_id_;
   std::string persistent_namespace_id_;

--- a/content/public/common/content_switches.cc
+++ b/content/public/common/content_switches.cc
@@ -928,6 +928,10 @@ const char kRemoteDebuggingSocketName[]     = "remote-debugging-socket-name";
 const char kRendererWaitForJavaDebugger[] = "renderer-wait-for-java-debugger";
 #endif
 
+// Enable the aggressive flushing of DOM Storage to minimize data loss.
+const char kEnableAggressiveDOMStorageFlushing[] =
+    "enable-aggressive-domstorage-flushing";
+
 // Disable web audio API.
 const char kDisableWebAudio[]               = "disable-webaudio";
 

--- a/content/public/common/content_switches.h
+++ b/content/public/common/content_switches.h
@@ -89,6 +89,7 @@ extern const char kDisableV8IdleTasks[];
 CONTENT_EXPORT extern const char kDisableWebSecurity[];
 CONTENT_EXPORT extern const char kDomAutomationController[];
 extern const char kEnable2dCanvasClipAntialiasing[];
+CONTENT_EXPORT extern const char kEnableAggressiveDOMStorageFlushing[];
 CONTENT_EXPORT extern const char kEnableBleedingEdgeRenderingFastPaths[];
 CONTENT_EXPORT extern const char kEnableCredentialManagerAPI[];
 CONTENT_EXPORT extern const char kEnableBeginFrameScheduling[];


### PR DESCRIPTION
Android WebView does not save data during shutdown like Chrome does.
Adding an --enable-aggressive-domstorage-flushing flag to return the
DOM Storage implementation to the prior implementation which had a 1
sec. timer to flush the commit queue.

NOTRY=true
NOPRESUBMIT=true
TBR=jsbell
BUG=479767

Review URL: https://codereview.chromium.org/1129233003

Cr-Commit-Position: refs/heads/master@{#329070}
(cherry picked from commit a1f8d834ce9fc89e5e409e08bb00173c37854329)

Review URL: https://codereview.chromium.org/1138843002

Cr-Commit-Position: refs/branch-heads/2357@{#364}
Cr-Branched-From: 59d4494849b405682265ed5d3f5164573b9a939b-refs/heads/master@{#323860}
(cherry picked from commit 5eba2222bb5e2f70618d3fa3017d19a91504e823)