### PR TITLE
[Lite][Android] Crash found when executes "selection.addRange", caused by icu feature.

### DIFF
--- a/base/icu_alternatives_on_android/icu_utils.cc
+++ b/base/icu_alternatives_on_android/icu_utils.cc
@@ -303,9 +303,9 @@ bool isPunct(UChar32 c) {
 }
 
 bool hasLineBreakingPropertyComplexContext(UChar32 c) {
-  // Java:: Character getType LINE_SEPARATOR
-  JNIEnv* env = AttachCurrentThread();
-  return Java_IcuUtils_isLineSeparator(env, c);
+  // Don't support this now. Need UCharacter(ICU4j).
+  // Impact line breaks in THAI,LAO,KHmer.
+  return false;
 }
 
 UChar32 mirroredChar(UChar32 c) {

--- a/base/icu_alternatives_on_android/java/src/org/chromium/base/icu/IcuUtils.java
+++ b/base/icu_alternatives_on_android/java/src/org/chromium/base/icu/IcuUtils.java
@@ -311,11 +311,6 @@ public class IcuUtils {
     }
 
     @CalledByNative
-    private static boolean isLineSeparator(int codePoint) {
-        return (Character.getType(codePoint) & Character.LINE_SEPARATOR) != 0;
-    }
-
-    @CalledByNative
     private static int mirroredChar(int codePoint) {
         // AndroidCharacter.getMirror ?
         return codePoint;


### PR DESCRIPTION
The line break property for ICU can't be supported without extra libs like ICU4j.
BUG=XWALK-4645