### PR TITLE
Fix the conflicts of ResourceExtractor on M45

### DIFF
--- a/base/android/java/src/org/chromium/base/ResourceExtractor.java
+++ b/base/android/java/src/org/chromium/base/ResourceExtractor.java
@@ -128,6 +128,11 @@ public class ResourceExtractor {
             try {
                 // Extract all files that don't already exist.
                 for (ResourceEntry entry : sResourcesToExtract) {
+                    // Loading "icudtl.dat" from "assets/"" currently does not work with either
+                    // embedded mode (the file is in raw/res) or shared mode (the app's context is
+                    // used to retrieve the AssetManager, not Crosswalk's). We thus need to put
+                    // those special files in a different directory so that we leverage the fallback
+                    // code in Chromium to load these files from disk.
                     File dir = isAppDataFile(entry.extractedFileName) ? appDataDir : outputDir;
                     File output = new File(dir, entry.extractedFileName);
                     if (output.exists()) {
@@ -322,6 +327,10 @@ public class ResourceExtractor {
 
         try {
             mExtractTask.get();
+            // ResourceExtractor is not needed any more.
+            // Release static objects to avoid leak of Context.
+            sInterceptor = null;
+            sInstance = null;
         } catch (CancellationException e) {
             // Don't leave the files in an inconsistent state.
             deleteFiles();

--- a/base/android/java/src/org/chromium/base/ResourceExtractor.java
+++ b/base/android/java/src/org/chromium/base/ResourceExtractor.java
@@ -41,6 +41,19 @@ public class ResourceExtractor {
 
     private static ResourceEntry[] sResourcesToExtract = new ResourceEntry[0];
 
+    private static ResourceInterceptor sInterceptor = null;
+
+    public interface ResourceInterceptor {
+        public boolean shouldInterceptLoadRequest(String resource);
+        public InputStream openRawResource(String resource);
+    }
+
+    private static boolean isAppDataFile(String file) {
+        return ICU_DATA_FILENAME.equals(file)
+                || V8_NATIVES_DATA_FILENAME.equals(file)
+                || V8_SNAPSHOT_DATA_FILENAME.equals(file);
+    }
+
     /**
      * Holds information about a res/raw file (e.g. locale .pak files).
      */
@@ -93,6 +106,7 @@ public class ResourceExtractor {
 
         private void doInBackgroundImpl() {
             final File outputDir = getOutputDir();
+            final File appDataDir = getAppDataDir();
             if (!outputDir.exists() && !outputDir.mkdirs()) {
                 Log.e(LOGTAG, "Unable to create pak resources directory!");
                 return;
@@ -114,13 +128,19 @@ public class ResourceExtractor {
             try {
                 // Extract all files that don't already exist.
                 for (ResourceEntry entry : sResourcesToExtract) {
-                    File output = new File(outputDir, entry.extractedFileName);
+                    File dir = isAppDataFile(entry.extractedFileName) ? appDataDir : outputDir;
+                    File output = new File(dir, entry.extractedFileName);
                     if (output.exists()) {
                         continue;
                     }
                     beginTraceSection("ExtractResource");
-                    InputStream inputStream = mContext.getResources().openRawResource(
-                            entry.resourceId);
+                    InputStream inputStream;
+                    if (sInterceptor != null
+                            && sInterceptor.shouldInterceptLoadRequest(entry.extractedFileName)) {
+                        inputStream = sInterceptor.openRawResource(entry.extractedFileName);
+                    } else {
+                        inputStream = mContext.getResources().openRawResource(entry.resourceId);
+                    }
                     try {
                         extractResourceHelper(inputStream, output, buffer);
                     } finally {
@@ -251,6 +271,19 @@ public class ResourceExtractor {
             sInstance = new ResourceExtractor(context);
         }
         return sInstance;
+    }
+
+    /**
+     * Allow embedders to intercept the resource loading process. Embedders may
+     * want to load paks from res/raw instead of assets, since assets are not
+     * supported in Android library project.
+     * @param intercepter The instance of intercepter which provides the files list
+     * to intercept and the inputstream for the files it wants to intercept with.
+     */
+    public static void setResourceInterceptor(ResourceInterceptor interceptor) {
+        assert (sInstance == null || sInstance.mExtractTask == null)
+                : "Must be called before startExtractingResources is called";
+        sInterceptor = interceptor;
     }
 
     /**


### PR DESCRIPTION
The upstream changes from M45 almost make our following commits unnecessary. This patch is to resolve the conflicts and restore previous functionality.

This patch rebased the commits below:
4ba805f1c8d470eb7c32348f2d3c8df28199f7ce
c715ce1b87516f983620c32919a0f99db095bcbe

The commit below can be discared:
31d05593d00b70050a9b4fc6d14f33a5b56fc60e

After this patch get merged, I will send another PR to Crosswalk repository. Then XWALK-4755 can be fixed.