### PR TITLE
Add 'Optimize for size, Os' compile option

### DIFF
--- a/build/android/increase_size_for_speed.gypi
+++ b/build/android/increase_size_for_speed.gypi
@@ -14,7 +14,11 @@
       'target_conditions': [
         ['_toolset=="target"', {
           'conditions': [
-            ['OS=="android"', {
+            ['OS=="android" and use_optimize_for_size_compile_option==1', {
+              'cflags!': ['-O2'],
+              'cflags': ['-Os'],
+            }],
+            ['OS=="android" and use_optimize_for_size_compile_option==0', {
               'cflags!': ['-Os'],
               'cflags': ['-O2'],
             }],


### PR DESCRIPTION
Modules like Base,Skia,cc,V8 use "increase size for speed" to
run faster.In Lite we prefer to decrease size.

With lzma, 677K binary size reduced for embedded_shell.apk
Without lzma, 820K binary size reduced.

Slight performance downgrade found,it is an acceptable balance.