### PR TITLE
Web Audio bug fix

### DIFF
--- a/content/browser/media/android/browser_media_player_manager.cc
+++ b/content/browser/media/android/browser_media_player_manager.cc
@@ -144,9 +144,7 @@ BrowserMediaPlayerManager::BrowserMediaPlayerManager(
     RenderFrameHost* render_frame_host,
     MediaPlayersObserver* audio_monitor)
     : render_frame_host_(render_frame_host),
-#ifndef DISABLE_WEB_AUDIO
       audio_monitor_(audio_monitor),
-#endif
       fullscreen_player_id_(kInvalidMediaPlayerId),
       fullscreen_player_is_released_(false),
       web_contents_(WebContents::FromRenderFrameHost(render_frame_host)),
@@ -285,13 +283,8 @@ void BrowserMediaPlayerManager::OnVideoSizeChanged(
 
 void BrowserMediaPlayerManager::OnAudibleStateChanged(
     int player_id, bool is_audible) {
-#ifndef DISABLE_WEB_AUDIO
   audio_monitor_->OnAudibleStateChanged(
       render_frame_host_, player_id, is_audible);
-#else
-  (void) player_id;
-  (void) is_audible;
-#endif
 }
 
 void BrowserMediaPlayerManager::OnWaitingForDecryptionKey(int player_id) {
@@ -557,9 +550,7 @@ void BrowserMediaPlayerManager::RemovePlayer(int player_id) {
       ReleaseMediaResources(player_id);
       (*it)->DeleteOnCorrectThread();
       players_.weak_erase(it);
-#ifndef DISABLE_WEB_AUDIO
       audio_monitor_->RemovePlayer(render_frame_host_, player_id);
-#endif
       break;
     }
   }

--- a/content/browser/media/android/browser_media_player_manager.h
+++ b/content/browser/media/android/browser_media_player_manager.h
@@ -176,9 +176,7 @@ class CONTENT_EXPORT BrowserMediaPlayerManager
 
   RenderFrameHost* const render_frame_host_;
 
-#ifndef DISABLE_WEB_AUDIO
   MediaPlayersObserver* audio_monitor_;
-#endif
 
   // An array of managed players.
   ScopedVector<media::MediaPlayerAndroid> players_;

--- a/content/browser/media/media_web_contents_observer.cc
+++ b/content/browser/media/media_web_contents_observer.cc
@@ -39,11 +39,9 @@ void MediaWebContentsObserver::RenderFrameDeleted(
   // detaching CDMs from media players yet. See http://crbug.com/330324
   media_player_managers_.erase(key);
 
-#ifndef DISABLE_WEB_AUDIO
   MediaPlayersObserver* audio_observer = GetMediaPlayersObserver();
   if (audio_observer)
     audio_observer->RenderFrameDeleted(render_frame_host);
-#endif
 #endif
   // TODO(xhwang): Currently MediaWebContentsObserver, BrowserMediaPlayerManager
   // and BrowserCdmManager all run on browser UI thread. So this call is okay.

--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -785,7 +785,6 @@ void RenderProcessHostImpl::CreateMessageFilters() {
       BrowserMainLoop::GetInstance()->user_input_monitor()));
   // The AudioRendererHost needs to be available for lookup, so it's
   // stashed in a member variable.
-#ifndef DISABLE_WEB_AUDIO
   audio_renderer_host_ = new AudioRendererHost(
       GetID(),
       audio_manager,
@@ -793,7 +792,6 @@ void RenderProcessHostImpl::CreateMessageFilters() {
       media_internals,
       media_stream_manager);
   AddFilter(audio_renderer_host_.get());
-#endif
   AddFilter(
       new MidiHost(GetID(), BrowserMainLoop::GetInstance()->midi_manager()));
   AddFilter(new VideoCaptureHost(media_stream_manager));
@@ -2212,11 +2210,9 @@ void RenderProcessHostImpl::SetBackgrounded(bool backgrounded) {
   if (!child_process_launcher_.get() || child_process_launcher_->IsStarting())
     return;
 
-#ifndef DISABLE_WEB_AUDIO
   // Don't background processes which have active audio streams.
   if (backgrounded_ && audio_renderer_host_->HasActiveAudio())
     return;
-#endif
 
   const base::CommandLine* command_line =
       base::CommandLine::ForCurrentProcess();
@@ -2350,11 +2346,7 @@ void RenderProcessHostImpl::OnProcessLaunchFailed() {
 
 scoped_refptr<AudioRendererHost>
 RenderProcessHostImpl::audio_renderer_host() const {
-#ifndef DISABLE_WEB_AUDIO
   return audio_renderer_host_;
-#else
-  return nullptr;
-#endif
 }
 
 void RenderProcessHostImpl::OnUserMetricsRecordAction(
@@ -2484,9 +2476,7 @@ void RenderProcessHostImpl::DecrementWorkerRefCount() {
 
 void RenderProcessHostImpl::GetAudioOutputControllers(
     const GetAudioOutputControllersCallback& callback) const {
-#ifndef DISABLE_WEB_AUDIO
   audio_renderer_host()->GetOutputControllers(callback);
-#endif
 }
 
 }  // namespace content

--- a/content/browser/renderer_host/render_view_host_impl.cc
+++ b/content/browser/renderer_host/render_view_host_impl.cc
@@ -229,7 +229,6 @@ RenderViewHostImpl::RenderViewHostImpl(
 
   GetProcess()->EnableSendQueue();
 
-#ifndef DISABLE_WEB_AUDIO
   if (ResourceDispatcherHostImpl::Get()) {
     bool has_active_audio = false;
     if (has_initialized_audio_host) {
@@ -250,7 +249,6 @@ RenderViewHostImpl::RenderViewHostImpl(
                    !is_hidden(),
                    has_active_audio));
   }
-#endif
 }
 
 RenderViewHostImpl::~RenderViewHostImpl() {

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -351,9 +351,7 @@ WebContentsImpl::WebContentsImpl(BrowserContext* browser_context,
 #endif
 
 #if defined(OS_ANDROID)
-#ifndef DISABLE_WEB_AUDIO
   audio_state_provider_.reset(new MediaPlayersObserver(this));
-#endif
 #else
   audio_state_provider_.reset(new AudioStreamMonitor(this));
 #endif

--- a/content/content_browser.gypi
+++ b/content/content_browser.gypi
@@ -1556,18 +1556,6 @@
       'browser/android/java/jni_helper.cc',
       'browser/android/java/jni_helper.h',
     ],
-    'private_browser_sources_web_audio': [
-      'browser/android/media_players_observer.cc',
-      'browser/android/media_players_observer.h',
-      'browser/media/audio_state_provider.cc',
-      'browser/media/audio_state_provider.h',
-      'browser/media/audio_stream_monitor.cc',
-      'browser/media/audio_stream_monitor.h',
-      'browser/renderer_host/media/audio_renderer_host.cc',
-      'browser/renderer_host/media/audio_renderer_host.h',
-      'browser/renderer_host/media/audio_sync_reader.cc',
-      'browser/renderer_host/media/audio_sync_reader.h',
-    ],
     'webrtc_browser_sources': [
       'browser/media/webrtc_internals.cc',
       'browser/media/webrtc_internals.h',
@@ -1729,11 +1717,6 @@
       ],
     }, {
       'defines': ['DISABLE_DEVTOOLS'],
-    }],
-    ['disable_web_audio == 1', {
-      'sources!': [
-        '<@(private_browser_sources_web_audio)',
-      ],
     }],
     ['disable_notifications==1', {
       'sources!': [


### PR DESCRIPTION
Bring back MediaPlayersOberver and AudioRenderHost.

Remove MediaPlayersObserver will cause the Chrome_IO thread crash,
whereas remove AudioRenderHost will cause main thread crash.

BUG=XWALK-4965