### PR TITLE
Change start-up flag kDisableNotifications from jelly bean to ICS to …

### DIFF
--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -73,7 +73,7 @@ void SetContentCommandLineFlags(bool single_process,
 
   // Web Notifications are only supported on Android JellyBean and beyond.
   if (base::android::BuildInfo::GetInstance()->sdk_int() <
-      base::android::SDK_VERSION_JELLY_BEAN) {
+      base::android::SDK_VERSION_ICE_CREAM_SANDWICH_MR1) {
     parsed_command_line->AppendSwitch(switches::kDisableNotifications);
   }
 


### PR DESCRIPTION
…resolve no notifications on android 4.0

CCBUG=XWALK-4669
Related to:XWALK-3645
It's a regression caused by upstream dropping support for Android ICS and our subsequent patches to reenable it. So I back this patch to crosswalk15