### PR TITLE
Revert "Bug fix for minimum resources"

### DIFF
--- a/content/child/blink_platform_impl.cc
+++ b/content/child/blink_platform_impl.cc
@@ -907,7 +907,6 @@ const DataResource kDataResources[] = {
     {"mediaplayerOverlayPlay",
      IDR_MEDIAPLAYER_OVERLAY_PLAY_BUTTON,
      ui::SCALE_FACTOR_100P},
-    {"html.css", IDR_UASTYLE_HTML_CSS, ui::SCALE_FACTOR_NONE},
 #endif
     {"panIcon", IDR_PAN_SCROLL_ICON, ui::SCALE_FACTOR_100P},
     {"searchCancel", IDR_SEARCH_CANCEL, ui::SCALE_FACTOR_100P},
@@ -922,6 +921,7 @@ const DataResource kDataResources[] = {
     {"generatePasswordHover",
      IDR_PASSWORD_GENERATION_ICON_HOVER,
      ui::SCALE_FACTOR_100P},
+    {"html.css", IDR_UASTYLE_HTML_CSS, ui::SCALE_FACTOR_NONE},
     {"quirks.css", IDR_UASTYLE_QUIRKS_CSS, ui::SCALE_FACTOR_NONE},
     {"view-source.css", IDR_UASTYLE_VIEW_SOURCE_CSS, ui::SCALE_FACTOR_NONE},
     {"themeChromium.css",


### PR DESCRIPTION
This reverts commit ef3e7c6eadb30fccdd7c0881119d659a5aedad86.

For crosswalk-lite-10, a macro named IDR_UASTYLE_HTML_CSS generate in
./gen/blink/public/resources/grit/blink_resources.h,
whether the option use_minimum_resources is enable or disable.
In crosswalk-lite, IDR_UASTYLE_HTML_CSS would not generate if we disable
use_minimum_resources, so we need add it back to avoid the compiling
error.

Simply remove IDR_UASTYLE_HTML_CSS html.css will cause the layout mess
up.