### PR TITLE
[Android] Don't depend on android support v13 library

### DIFF
--- a/build/java.gypi
+++ b/build/java.gypi
@@ -56,6 +56,7 @@
     'input_jars_paths': [ '<(android_jar)' ],
     'additional_src_dirs': [],
     'javac_includes': [],
+    'filtered_java_files%': '',
     'jar_name': '<(_target_name).jar',
     'jar_dir': '<(PRODUCT_DIR)/lib.java',
     'jar_path': '<(intermediate_dir)/<(jar_name)',
@@ -260,7 +261,7 @@
       'variables': {
         'extra_args': [],
         'extra_inputs': [],
-        'java_sources': ['>!@(find >(java_in_dir)>(java_in_dir_suffix) >(additional_src_dirs) -name "*.java")'],
+        'java_sources': ['>!@(find >(java_in_dir)>(java_in_dir_suffix) >(additional_src_dirs) -name "*.java" >(filtered_java_files))'],
         'conditions': [
           ['enable_errorprone == 1', {
             'extra_inputs': [

--- a/content/content.gyp
+++ b/content/content.gyp
@@ -440,7 +440,6 @@
             '../ui/android/ui_android.gyp:ui_java',
             '../ui/touch_selection/ui_touch_selection.gyp:selection_event_type_java',
             '../ui/touch_selection/ui_touch_selection.gyp:touch_handle_orientation_java',
-            '../third_party/android_tools/android_tools.gyp:android_support_v13_javalib',
             '../third_party/WebKit/public/blink_headers.gyp:blink_headers_java',
             '../ui/mojo/geometry/mojo_bindings.gyp:mojo_geometry_bindings',
             'common_aidl',
@@ -461,6 +460,7 @@
           ],
           'variables': {
             'java_in_dir': '../content/public/android/java',
+            'filtered_java_files': ' ! -name BackgroundSyncLauncherService.java',
             'has_java_resources': 1,
             'R_package': 'org.chromium.content',
             'R_package_relpath': 'org/chromium/content',


### PR DESCRIPTION
The commit "[BackgroundSync] Reland of Launch Chrome on Android for One-Shot" in
https://codereview.chromium.org/1140813006/#ps340001 is
On Android devices BackgroundSync needs to launch the browser the next time the device
goes online if a one-shot sync is registered.
The class of the service will be moved to xwalk/app/android/app_support. It will be compiled
in app-side if customer want to try this feature.

BUG=XWALK-5092