### PR TITLE
Make the HTML tag "video" unknown for WebKit if WebVideo disabled

### DIFF
--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -228,6 +228,11 @@ void SetRuntimeFeaturesDefaultsAndUpdateFromArgs(
           blink::WebString::fromLatin1(feature), false);
     }
   }
+
+// Make the tags of  disabled features unknown for WebKit
+#ifdef DISABLE_WEB_VIDEO
+  WebRuntimeFeatures::enableMediaPlayer(false);
+#endif
 }
 
 }  // namespace content


### PR DESCRIPTION
I've awared of this problem during investigation of XWALK-5147. It caused by user trying to access a webpage with complicated 'video' tag related content when WebVideo is disabled.

Although the calling of system Media Player is excluded when disable
WebVideo, if the WebKit still takes <video> as a known tag, there will
be risk of many unexpected problems.

