### PR TITLE
Web-Video-related resources should be controled by 'disable_web_video'

### DIFF
--- a/content/child/blink_platform_impl.cc
+++ b/content/child/blink_platform_impl.cc
@@ -793,7 +793,7 @@ struct DataResource {
 const DataResource kDataResources[] = {
     {"missingImage", IDR_BROKENIMAGE, ui::SCALE_FACTOR_100P},
     {"missingImage@2x", IDR_BROKENIMAGE, ui::SCALE_FACTOR_200P},
-#if !defined(USE_MINIMUM_RESOURCES)
+#if !defined(DISABLE_WEB_VIDEO)
     {"mediaplayerPause", IDR_MEDIAPLAYER_PAUSE_BUTTON, ui::SCALE_FACTOR_100P},
     {"mediaplayerPauseHover",
      IDR_MEDIAPLAYER_PAUSE_BUTTON_HOVER,


### PR DESCRIPTION
It causes the problem of lost 'Play' button in Video Element.