### PR TITLE
[Android] Fix crash in unit test

### DIFF
--- a/ui/android/java/src/org/chromium/ui/VSyncMonitor.java
+++ b/ui/android/java/src/org/chromium/ui/VSyncMonitor.java
@@ -96,6 +96,7 @@ public class VSyncMonitor {
                 @Override
                 public void doFrame(long frameTimeNanos) {
                     TraceEvent.begin("VSync");
+                    mHandler.removeCallbacks(mSyntheticVSyncRunnable);
                     if (useEstimatedRefreshPeriod && mConsecutiveVSync) {
                         // Display.getRefreshRate() is unreliable on some platforms.
                         // Adjust refresh period- initial value is based on Display.getRefreshRate()
@@ -210,10 +211,9 @@ public class VSyncMonitor {
         // frame callback even when we post a synthetic frame callback. If the
         // frame callback is honored before the synthetic callback, we simply
         // remove the synthetic callback.
-        postSyntheticVSyncIfNecessary(); //check this
-        mChoreographer.postFrameCallback(mVSyncFrameCallback);
         if (isVSyncSignalAvailable()) {
             mConsecutiveVSync = mInsideVSync;
+            postSyntheticVSyncIfNecessary();
             mChoreographer.postFrameCallback(mVSyncFrameCallback);
         } else {
             postRunnableCallback();


### PR DESCRIPTION
The change of VSyncMonitor in the commit af926cfcaed81686e6dbf782932b22deed1bef4c
causes crash of XWalkCoreShell and XWalkCoreInternallShell,
and then blocks a lot of test cases.

This commit is to fix the crash.

Related bug: XWALK-5241