### PR TITLE
[Android] Fix crash in unit test

### DIFF
--- a/content/renderer/render_frame_impl.cc
+++ b/content/renderer/render_frame_impl.cc
@@ -4612,9 +4612,9 @@ void RenderFrameImpl::NavigateInternal(
     base::TimeTicks renderer_navigation_start = base::TimeTicks::Now();
 
     // Perform a navigation to a data url if needed.
-    if (!common_params.base_url_for_data_url.is_empty() ||
-        (browser_side_navigation &&
-         common_params.url.SchemeIs(url::kDataScheme))) {
+    if ((!common_params.base_url_for_data_url.is_empty() ||
+         browser_side_navigation) &&
+        common_params.url.SchemeIs(url::kDataScheme)) {
       LoadDataURL(common_params, frame_);
     } else {
       // Load the request.


### PR DESCRIPTION
Load data when the scheme of url is data:.
The test case is ShouldOverrideUrlLoadingTest#testDoesNotCauseOnReceivedError
in XWalkCoreTest.

BUG=XWALK-5241