### PR TITLE
[Windows]Enable presentation API

### DIFF
--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -204,8 +204,13 @@ void SetRuntimeFeaturesDefaultsAndUpdateFromArgs(
         std::string("GeometryInterfaces"), true);
   }
 
+#if defined(OS_WIN)
+  // FIXME: Remove this condition after rebase to chromium v47.
+  WebRuntimeFeatures::enablePresentationAPI(true);
+#else
   if (command_line.HasSwitch(switches::kDisablePresentationAPI))
     WebRuntimeFeatures::enablePresentationAPI(false);
+#endif
 
   // Enable explicitly enabled features, and then disable explicitly disabled
   // ones.


### PR DESCRIPTION
The demo at https://storage.googleapis.com/presentation-api/index.html
can be used to see how the API is works.
The Crosswalk Presentation API implementation on Windows requires
having a connected non-primary display (either wired (HDMI, Display Port, ...)
or wireless (miracast)).

BUG=XWALK-4811