### PR TITLE
[Android] Expose the constructor of ContentView

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/ContentView.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ContentView.java
@@ -56,7 +56,7 @@ public class ContentView extends FrameLayout
      *                access the current theme, resources, etc.
      * @param cvc A pointer to the content view core managing this content view.
      */
-    ContentView(Context context, ContentViewCore cvc) {
+    public ContentView(Context context, ContentViewCore cvc) {
         super(context, null, android.R.attr.webViewStyle);
 
         if (getScrollBarStyle() == View.SCROLLBARS_INSIDE_OVERLAY) {


### PR DESCRIPTION
Unlike WebView, XWalkView uses a ContentView object as its child view,
which is actually receiving all kinds of events such as touching and
clicking. To let the XWalkView object receive these events too, it's
necessary to override relevant methods of ContentView and redirect
them to the XWalkView object. So we add XWalkContentView and have it
extend ContentView. To make this possible, the contructor of ContentView
must be public.

XWalkContentView is a temporary solution. We are targeting to optimize
the hierarchy of XWalkView to make it more like WebView. This task can
be tracked via XWALK-6118.

BUG=XWALK-6014