### PR TITLE
[Windows] Support RealSense Cameras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,6 +339,7 @@ v8.log
 /third_party/libphonenumber/libphonenumber.xml
 /third_party/libphonenumber/libphonenumber_without_metadata.xml
 /third_party/libphonenumber/src
+/third_party/libpxc
 /third_party/libsrtp
 /third_party/libvpx
 /third_party/libwebm/source

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -78,6 +78,9 @@ const char kForceWaveAudio[] = "force-wave-audio";
 // http://crbug.com/259165 for more details.
 const char kTrySupportedChannelLayouts[] = "try-supported-channel-layouts";
 
+// Use RSSDK for video capture.
+const char kUseRsVideoCapture[] = "use-rs-video-capture";
+
 // Number of buffers to use for WaveOut.
 const char kWaveOutBuffers[] = "waveout-buffers";
 #endif

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -40,6 +40,7 @@ MEDIA_EXPORT extern const char kForceDirectShowVideoCapture[];
 MEDIA_EXPORT extern const char kForceMediaFoundationVideoCapture[];
 MEDIA_EXPORT extern const char kForceWaveAudio[];
 MEDIA_EXPORT extern const char kTrySupportedChannelLayouts[];
+MEDIA_EXPORT extern const char kUseRsVideoCapture[];
 MEDIA_EXPORT extern const char kWaveOutBuffers[];
 #endif
 

--- a/media/capture/video/video_capture_device.cc
+++ b/media/capture/video/video_capture_device.cc
@@ -92,6 +92,8 @@ const char* VideoCaptureDevice::Name::GetCaptureApiTypeString() const {
       return "Media Foundation";
     case DIRECT_SHOW:
       return "Direct Show";
+    case RSSDK:
+      return "RSSDK";
     default:
       NOTREACHED() << "Unknown Video Capture API type!";
       return "Unknown API";

--- a/media/capture/video/video_capture_device.h
+++ b/media/capture/video/video_capture_device.h
@@ -52,7 +52,12 @@ class MEDIA_EXPORT VideoCaptureDevice {
     };
 #elif defined(OS_WIN)
     // Windows targets Capture Api type: it can only be set on construction.
-    enum CaptureApiType { MEDIA_FOUNDATION, DIRECT_SHOW, API_TYPE_UNKNOWN };
+    enum CaptureApiType {
+      MEDIA_FOUNDATION,
+      DIRECT_SHOW,
+      RSSDK,
+      API_TYPE_UNKNOWN
+    };
 #elif defined(OS_MACOSX)
     // Mac targets Capture Api type: it can only be set on construction.
     enum CaptureApiType { AVFOUNDATION, QTKIT, DECKLINK, API_TYPE_UNKNOWN };

--- a/media/capture/video/win/video_capture_device_factory_win.cc
+++ b/media/capture/video/win/video_capture_device_factory_win.cc
@@ -19,6 +19,11 @@
 #include "media/base/media_switches.h"
 #include "media/base/win/mf_initializer.h"
 #include "media/capture/video/win/video_capture_device_mf_win.h"
+#if defined(USE_RSSDK)
+#include "media/capture/video/win/video_capture_device_rs_win.h"
+#else
+#include "media/capture/video/win/video_capture_device_rs_win_null.h"
+#endif
 #include "media/capture/video/win/video_capture_device_win.h"
 
 using base::win::ScopedCoMem;
@@ -377,6 +382,8 @@ VideoCaptureDeviceFactoryWin::VideoCaptureDeviceFactoryWin() {
   // can also be forced if appropriate flag is set and we are in Windows 7 or
   // 8 in non-Metro mode.
   const base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
+  use_rssdk_ = cmd_line->HasSwitch(switches::kUseRsVideoCapture) &&
+      VideoCaptureDeviceRSWin::IsSupported();
   use_media_foundation_ =
       (base::win::IsMetroProcess() &&
        !cmd_line->HasSwitch(switches::kForceDirectShowVideoCapture)) ||
@@ -388,7 +395,13 @@ scoped_ptr<VideoCaptureDevice> VideoCaptureDeviceFactoryWin::Create(
     const Name& device_name) {
   DCHECK(thread_checker_.CalledOnValidThread());
   scoped_ptr<VideoCaptureDevice> device;
-  if (device_name.capture_api_type() == Name::MEDIA_FOUNDATION) {
+  if (device_name.capture_api_type() == Name::RSSDK) {
+    DCHECK(device_name.capture_api_type() == Name::RSSDK);
+    device.reset(new VideoCaptureDeviceRSWin(device_name));
+    DVLOG(1) << " RSSDK Device: " << device_name.name();
+    if (!static_cast<VideoCaptureDeviceRSWin*>(device.get())->Init())
+      device.reset();
+  } else if (device_name.capture_api_type() == Name::MEDIA_FOUNDATION) {
     DCHECK(PlatformSupportsMediaFoundation());
     device.reset(new VideoCaptureDeviceMFWin(device_name));
     DVLOG(1) << " MediaFoundation Device: " << device_name.name();
@@ -411,7 +424,9 @@ scoped_ptr<VideoCaptureDevice> VideoCaptureDeviceFactoryWin::Create(
 
 void VideoCaptureDeviceFactoryWin::GetDeviceNames(Names* device_names) {
   DCHECK(thread_checker_.CalledOnValidThread());
-  if (use_media_foundation_) {
+  if (use_rssdk_) {
+    VideoCaptureDeviceRSWin::GetDeviceNames(device_names);
+  } else if (use_media_foundation_) {
     GetDeviceNamesMediaFoundation(device_names);
   } else {
     GetDeviceNamesDirectShow(device_names);
@@ -422,7 +437,9 @@ void VideoCaptureDeviceFactoryWin::GetDeviceSupportedFormats(
     const Name& device,
     VideoCaptureFormats* formats) {
   DCHECK(thread_checker_.CalledOnValidThread());
-  if (use_media_foundation_)
+  if (use_rssdk_)
+    VideoCaptureDeviceRSWin::GetDeviceSupportedFormats(device, formats);
+  else if (use_media_foundation_)
     GetDeviceSupportedFormatsMediaFoundation(device, formats);
   else
     GetDeviceSupportedFormatsDirectShow(device, formats);

--- a/media/capture/video/win/video_capture_device_factory_win.h
+++ b/media/capture/video/win/video_capture_device_factory_win.h
@@ -30,6 +30,7 @@ class MEDIA_EXPORT VideoCaptureDeviceFactoryWin
 
  private:
   bool use_media_foundation_;
+  bool use_rssdk_;
 
   DISALLOW_COPY_AND_ASSIGN(VideoCaptureDeviceFactoryWin);
 };

--- a/media/capture/video/win/video_capture_device_rs_win.cc
+++ b/media/capture/video/win/video_capture_device_rs_win.cc
@@ -1,0 +1,382 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "media/capture/video/win/video_capture_device_rs_win.h"
+
+#include "base/lazy_instance.h"
+#include "base/logging.h"
+#include "base/memory/ref_counted.h"
+#include "base/message_loop/message_loop.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/sys_string_conversions.h"
+#include "base/strings/utf_string_conversions.h"
+#include "third_party/libpxc/include/pxcimage.h"
+
+namespace media {
+
+#define PXC_SUCCEEDED(status) (((pxcStatus)(status)) >= PXC_STATUS_NO_ERROR)
+#define PXC_FAILED(status) (((pxcStatus)(status)) < PXC_STATUS_NO_ERROR)
+
+// Map of color pixel formats of PXCImage::PixelFormat to Chromium ones.
+static const struct {
+  PXCImage::PixelFormat pxc_format;
+  VideoCapturePixelFormat chromium_format;
+} pixel_formats[] = {
+    {PXCImage::PIXEL_FORMAT_RGB24, VIDEO_CAPTURE_PIXEL_FORMAT_RGB24},
+    {PXCImage::PIXEL_FORMAT_RGB32, VIDEO_CAPTURE_PIXEL_FORMAT_ARGB},
+    {PXCImage::PIXEL_FORMAT_NV12, VIDEO_CAPTURE_PIXEL_FORMAT_NV12},
+    {PXCImage::PIXEL_FORMAT_YUY2, VIDEO_CAPTURE_PIXEL_FORMAT_YUY2}
+};
+
+static VideoCapturePixelFormat PixelFormatPxcToChromium(
+    const PXCImage::PixelFormat pxc_format) {
+  for (size_t i = 0; i < arraysize(pixel_formats); ++i) {
+    if (pxc_format == pixel_formats[i].pxc_format)
+      return pixel_formats[i].chromium_format;
+  }
+  DLOG(ERROR) << "Device supports an unknown media type of Chromium "
+     << PXCImage::PixelFormatToString(pxc_format);
+  return VIDEO_CAPTURE_PIXEL_FORMAT_UNKNOWN;
+}
+
+static PXCImage::PixelFormat PixelFormatChromiumToPxc(
+    const VideoCapturePixelFormat chromium_format) {
+  for (size_t i = 0; i < arraysize(pixel_formats); ++i) {
+    if (chromium_format == pixel_formats[i].chromium_format)
+      return pixel_formats[i].pxc_format;
+  }
+  DLOG(ERROR) << "Chromium requests an unknown media type of device "
+     << VideoCaptureFormat::PixelFormatToString(chromium_format);
+  return PXCImage::PIXEL_FORMAT_ANY;
+}
+
+bool VideoCaptureDeviceRSWin::IsSupported() {
+  PXCSession* session = PXCSession_Create();
+  if (!session) return false;
+  return true;
+}
+
+void VideoCaptureDeviceRSWin::GetDeviceNames(Names* device_names) {
+  PXCSession* session = PXCSession_Create();
+  if (!session) {
+    DLOG(ERROR) << "Failed to create PXCSession";
+    return;
+  }
+
+  PXCSession::ImplDesc templat = {};
+  templat.group = PXCSession::IMPL_GROUP_SENSOR;
+  templat.subgroup = PXCSession::IMPL_SUBGROUP_VIDEO_CAPTURE;
+  PXCSession::ImplDesc desc;
+  int module_index = 0;
+  while (PXC_SUCCEEDED(session->QueryImpl(&templat, module_index, &desc))) {
+    PXCCapture* capture = NULL;
+    if (PXC_FAILED(session->CreateImpl<PXCCapture>(&desc, &capture)))
+      continue;
+
+    DVLOG(1) << "RSSDK capture module: " << desc.friendlyName;
+
+    for (int i = 0; i < capture->QueryDeviceNum(); i++) {
+      PXCCapture::DeviceInfo device_info;
+      if (PXC_FAILED(capture->QueryDeviceInfo(i, &device_info))) break;
+
+      Name name(base::SysWideToUTF8(device_info.name),
+                base::SysWideToUTF8(device_info.did),
+                Name::RSSDK);
+      name.set_capabilities_id(base::IntToString(desc.iuid));
+      device_names->push_back(name);
+
+      DVLOG(1) << "RSSDK capture device: "
+          << base::SysWideToUTF8(device_info.name) << " "
+          << base::SysWideToUTF8(device_info.did);
+    }
+    module_index++;
+    capture->Release();
+  }
+  session->Release();
+}
+
+void VideoCaptureDeviceRSWin::GetDeviceSupportedFormats(
+    const Name& device_name, VideoCaptureFormats* formats) {
+  // RSSDK requires to create and initialize device to get supported formats.
+  // Postpone this task to VideoCaptureDeviceRSWin::Init() as it is too
+  // expensive to do here.
+}
+
+class SenseManagerHandler : public PXCSenseManager::Handler {
+ public:
+  explicit SenseManagerHandler(VideoCaptureDeviceRSWin* observer)
+      : observer_(observer) {}
+  virtual ~SenseManagerHandler() {}
+
+  // PXCSenseManager::Handler implementation.
+  virtual pxcStatus PXCAPI OnNewSample(pxcUID mid, PXCCapture::Sample* sample) {
+    if (observer_->OnNewSample(sample))
+      return PXC_STATUS_NO_ERROR;
+    else
+      return PXC_STATUS_EXEC_ABORTED;
+  }
+  virtual void PXCAPI OnStatus(pxcUID mid, pxcStatus status) {
+    if (status < PXC_STATUS_NO_ERROR) {
+      observer_->SetErrorState("On PXCSenseManager error status");
+      return;
+    }
+  }
+ private:
+  VideoCaptureDeviceRSWin* observer_;
+};
+
+VideoCaptureDeviceRSWin::VideoCaptureDeviceRSWin(const Name& device_name)
+    : name_(device_name),
+      sense_manager_(NULL),
+      capturing_(false) {
+  DetachFromThread();
+}
+
+VideoCaptureDeviceRSWin::~VideoCaptureDeviceRSWin() {
+  DCHECK(CalledOnValidThread());
+}
+
+bool VideoCaptureDeviceRSWin::Init() {
+  DCHECK(CalledOnValidThread());
+  DVLOG(1) << "VideoCaptureDeviceRSWin:Init for device " << name_.name();
+
+  session_ = PXCSession_Create();
+  if (!session_) {
+    DLOG(ERROR) << "Failed to create PXCSession";
+    return false;
+  }
+
+  int iuid;
+  base::StringToInt(name_.capabilities_id(), &iuid);
+  if (PXC_FAILED(session_->CreateImpl<PXCCapture>(iuid, &capture_))) {
+    DLOG(ERROR) << "PXCSession failed to create PXCCapture with iuid " << iuid;
+    return false;
+  }
+
+  for (int i = 0; i < capture_->QueryDeviceNum(); i++) {
+    PXCCapture::DeviceInfo device_info;
+    if (PXC_FAILED(capture_->QueryDeviceInfo(i, &device_info))) break;
+    Name name(base::SysWideToUTF8(device_info.name),
+              base::SysWideToUTF8(device_info.did),
+              VideoCaptureDevice::Name::RSSDK);
+    if (name == name_) {
+      capture_device_ = capture_->CreateDevice(device_info.didx);
+      break;
+    }
+  }
+
+  if (!capture_device_) {
+    DLOG(ERROR) << "Failed to find PXCCapture::Device";
+    return false;
+  }
+
+  int num_profiles = capture_device_->QueryStreamProfileSetNum(
+      PXCCapture::STREAM_TYPE_COLOR);
+  DVLOG(1) << "Found " << num_profiles << " profiles.";
+  for (int profile_index = 0; profile_index < num_profiles; ++profile_index) {
+    PXCCapture::Device::StreamProfileSet profile_set = {};
+    if (PXC_FAILED(capture_device_->QueryStreamProfileSet(
+      PXCCapture::STREAM_TYPE_COLOR, profile_index, &profile_set)))
+      break;
+    DVLOG(1) << "Profile[" << profile_index << "]: "
+      << PXCImage::PixelFormatToString(profile_set.color.imageInfo.format)
+      << " (" << profile_set.color.imageInfo.width << "x"
+      << profile_set.color.imageInfo.height << ")"
+      << " @" << profile_set.color.frameRate.max << "fps";
+    profiles_.push_back(profile_set.color);
+  }
+  return true;
+}
+
+void VideoCaptureDeviceRSWin::AllocateAndStart(
+    const VideoCaptureParams& params,
+    scoped_ptr<Client> client) {
+  DCHECK(CalledOnValidThread());
+
+  base::AutoLock lock(lock_);
+
+  client_ = client.Pass();
+  DCHECK_EQ(capturing_, false);
+
+  sense_manager_ = PXCSenseManager::CreateInstance();
+  if (!sense_manager_) {
+    SetErrorState("Failed to create PXCSenseManager");
+    return;
+  }
+
+  DVLOG(1) << "Requested foramt: "
+      << VideoCaptureFormat::ToString(params.requested_format)
+      << " for device " << name_.name();
+
+  // The PXCCaptureManager instance is owned by the SenseManager.
+  PXCCaptureManager* capture_manager = sense_manager_->QueryCaptureManager();
+  if (!capture_manager) {
+    SetErrorState("Failed to get PXCCaptureManager");
+    return;
+  }
+
+  capture_manager->FilterByDeviceInfo(
+      const_cast<wchar_t*>(base::SysUTF8ToWide(name_.name()).c_str()),
+      const_cast<wchar_t*>(base::SysUTF8ToWide(name_.id()).c_str()),
+      0);
+
+  PXCCapture::Device::StreamProfile best_profile;
+  best_profile = GetBestMatchedProfile(params.requested_format, profiles_);
+
+  DVLOG(1) << "Best matched profile: "
+      << PXCImage::PixelFormatToString(best_profile.imageInfo.format)
+      << " (" << best_profile.imageInfo.width << "x"
+      << best_profile.imageInfo.height << ")"
+      << " @" << best_profile.frameRate.max << "fps";
+
+  PXCCapture::Device::StreamProfileSet requested_profile_set = {};
+  requested_profile_set.color = best_profile;
+  capture_manager->FilterByStreamProfiles(&requested_profile_set);
+
+  PXCVideoModule::DataDesc desc = {};
+  desc.streams.color.frameRate.min = desc.streams.color.frameRate.max =
+      best_profile.frameRate.max;
+  desc.streams.color.sizeMin.height = desc.streams.color.sizeMax.height =
+      best_profile.imageInfo.height;
+  desc.streams.color.sizeMin.width = desc.streams.color.sizeMax.width =
+      best_profile.imageInfo.width;
+  desc.streams.color.options = best_profile.options;
+  if (PXC_FAILED(sense_manager_->EnableStreams(&desc))) {
+    SetErrorState("Failed to enable streams");
+    return;
+  }
+
+  sense_manager_handler_.reset(new SenseManagerHandler(this));
+
+  if (PXC_FAILED(sense_manager_->Init(sense_manager_handler_.get()))) {
+    SetErrorState("Failed to init PXCSenseManager.");
+    return;
+  }
+
+  if (PXC_FAILED(sense_manager_->StreamFrames(false))) {
+    SetErrorState("Failed to stream frames");
+    return;
+  }
+
+  PXCCapture::Device* pxc_device = capture_manager->QueryDevice();
+  if (!pxc_device) {
+    SetErrorState("Failed to query PXCCapture::Device");
+    return;
+  }
+
+  PXCCapture::Device::StreamProfileSet profiles = {};
+  if (PXC_FAILED(pxc_device->QueryStreamProfileSet(&profiles))) {
+    SetErrorState("Failed to query stream profiles");
+    return;
+  }
+
+  PXCCapture::Device::StreamProfile profile = profiles.color;
+  if (!profile.imageInfo.format) {
+    SetErrorState("Invalid image format");
+    return;
+  }
+
+  capture_format_.frame_size.SetSize(profile.imageInfo.width,
+                                     profile.imageInfo.height);
+  capture_format_.frame_rate = profile.frameRate.max;
+  capture_format_.pixel_format =
+      PixelFormatPxcToChromium(profile.imageInfo.format);
+
+  DVLOG(1) << "Set format: " << VideoCaptureFormat::ToString(capture_format_);
+
+  capturing_ = true;
+}
+
+void VideoCaptureDeviceRSWin::StopAndDeAllocate() {
+  DCHECK(CalledOnValidThread());
+  {
+    base::AutoLock lock(lock_);
+
+    if (capturing_) {
+      capturing_ = false;
+
+      sense_manager_->Close();
+      sense_manager_->Release();
+      capture_device_->Release();
+      capture_->Release();
+      session_->Release();
+
+      sense_manager_handler_.reset();
+      sense_manager_ = NULL;
+    }
+    client_.reset();
+  }
+}
+
+bool VideoCaptureDeviceRSWin::OnNewSample(PXCCapture::Sample* sample) {
+  if (sample->color) {
+    PXCImage* image = sample->color;
+    PXCImage::ImageInfo info = image->QueryInfo();
+
+    PXCImage::ImageData data;
+    if (PXC_FAILED(image->AcquireAccess(
+        PXCImage::ACCESS_READ, info.format, &data))) {
+      SetErrorState("Failed to access image data");
+      return false;
+    }
+
+    client_->OnIncomingCapturedData(
+        static_cast<uint8*> (data.planes[0]),
+        capture_format_.ImageAllocationSize(),
+        capture_format_, 0, base::TimeTicks::Now());
+
+    image->ReleaseAccess(&data);
+  }
+
+  return true;
+}
+
+void VideoCaptureDeviceRSWin::SetErrorState(const std::string& reason) {
+  DVLOG(1) << reason;
+  client_->OnError(reason);
+}
+
+bool VideoCaptureDeviceRSWin::CompareProfile(
+    const VideoCaptureFormat& requested,
+    const PXCCapture::Device::StreamProfile& lhs,
+    const PXCCapture::Device::StreamProfile& rhs) {
+  const int diff_height_lhs =
+      std::abs(lhs.imageInfo.height - requested.frame_size.height());
+  const int diff_height_rhs =
+      std::abs(rhs.imageInfo.height - requested.frame_size.height());
+  if (diff_height_lhs != diff_height_rhs)
+    return diff_height_lhs < diff_height_rhs;
+
+  const int diff_width_lhs =
+      std::abs(lhs.imageInfo.width - requested.frame_size.width());
+  const int diff_width_rhs =
+      std::abs(rhs.imageInfo.width - requested.frame_size.width());
+  if (diff_width_lhs != diff_width_rhs)
+    return diff_width_lhs < diff_width_rhs;
+
+  const float diff_fps_lhs =
+      std::fabs(lhs.frameRate.max - requested.frame_rate);
+  const float diff_fps_rhs =
+      std::fabs(rhs.frameRate.max - requested.frame_rate);
+  if (diff_fps_lhs != diff_fps_rhs)
+    return diff_fps_lhs < diff_fps_rhs;
+
+  // See the PXCImage::PixelFormat definition for formarts preference.
+  return lhs.imageInfo.format < rhs.imageInfo.format;
+}
+
+const PXCCapture::Device::StreamProfile&
+VideoCaptureDeviceRSWin::GetBestMatchedProfile(
+    const VideoCaptureFormat& requested,
+    const ProfileList& profiles) {
+  DCHECK(!profiles.empty());
+  const PXCCapture::Device::StreamProfile* best_match = &(*profiles.begin());
+  for (const PXCCapture::Device::StreamProfile& profile : profiles) {
+    if (CompareProfile(requested, profile, *best_match))
+      best_match = &profile;
+  }
+  return *best_match;
+}
+
+}  // namespace media

--- a/media/capture/video/win/video_capture_device_rs_win.h
+++ b/media/capture/video/win/video_capture_device_rs_win.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MEDIA_CAPTURE_VIDEO_WIN_VIDEO_CAPTURE_DEVICE_RS_WIN_H_
+#define MEDIA_CAPTURE_VIDEO_WIN_VIDEO_CAPTURE_DEVICE_RS_WIN_H_
+
+#include <list>
+#include <string>
+
+#include "base/synchronization/lock.h"
+#include "base/threading/non_thread_safe.h"
+#include "media/base/media_export.h"
+#include "media/capture/video/video_capture_device.h"
+#include "third_party/libpxc/include/pxccapture.h"
+#include "third_party/libpxc/include/pxcsensemanager.h"
+#include "third_party/libpxc/include/pxcsession.h"
+
+namespace media {
+
+class SenseManagerHandler;
+
+// Intel RealSense SDK (RSSDK) based implementation of VideoCaptureDevice.
+class MEDIA_EXPORT VideoCaptureDeviceRSWin : public base::NonThreadSafe,
+                                             public VideoCaptureDevice {
+ public:
+  explicit VideoCaptureDeviceRSWin(const Name& device_name);
+  ~VideoCaptureDeviceRSWin() override;
+
+  // Opens the device driver for this device.
+  bool Init();
+
+  // VideoCaptureDevice implementation.
+  void AllocateAndStart(const VideoCaptureParams& params,
+                        scoped_ptr<Client> client) override;
+  void StopAndDeAllocate() override;
+
+  // Utiliies used by VideoCaptureDeviceFactoryWin.
+  static bool IsSupported();
+  static void GetDeviceNames(Names* device_names);
+  static void GetDeviceSupportedFormats(const Name& device,
+                                        VideoCaptureFormats* formats);
+
+  // Callbacks for RSSDK device API.
+  bool OnNewSample(PXCCapture::Sample* sample);
+  void SetErrorState(const std::string& reason);
+
+ private:
+  typedef std::list<PXCCapture::Device::StreamProfile> ProfileList;
+
+  bool CompareProfile(
+    const VideoCaptureFormat& requested,
+    const PXCCapture::Device::StreamProfile& lhs,
+    const PXCCapture::Device::StreamProfile& rhs);
+
+  const PXCCapture::Device::StreamProfile& GetBestMatchedProfile(
+    const VideoCaptureFormat& requested,
+    const ProfileList& profiles);
+
+  Name name_;
+  PXCSession* session_;
+  PXCCapture* capture_;
+  PXCCapture::Device* capture_device_;
+  PXCSenseManager* sense_manager_;
+  ProfileList profiles_;
+  scoped_ptr<SenseManagerHandler> sense_manager_handler_;
+
+  base::Lock lock_;  // Used to guard the below variables.
+  scoped_ptr<VideoCaptureDevice::Client> client_;
+  VideoCaptureFormat capture_format_;
+  bool capturing_;
+
+  DISALLOW_IMPLICIT_CONSTRUCTORS(VideoCaptureDeviceRSWin);
+};
+
+}  // namespace media
+
+#endif  // MEDIA_CAPTURE_VIDEO_WIN_VIDEO_CAPTURE_DEVICE_RS_WIN_H_

--- a/media/capture/video/win/video_capture_device_rs_win_null.cc
+++ b/media/capture/video/win/video_capture_device_rs_win_null.cc
@@ -1,0 +1,21 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "media/capture/video/win/video_capture_device_rs_win_null.h"
+
+namespace media {
+
+bool VideoCaptureDeviceRSWin::IsSupported() {
+  return false;
+}
+
+void VideoCaptureDeviceRSWin::GetDeviceNames(Names* device_names) {
+}
+
+void VideoCaptureDeviceRSWin::GetDeviceSupportedFormats(
+    const Name& device,
+    VideoCaptureFormats* formats) {
+}
+
+}  // namespace media

--- a/media/capture/video/win/video_capture_device_rs_win_null.h
+++ b/media/capture/video/win/video_capture_device_rs_win_null.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MEDIA_CAPTURE_VIDEO_WIN_VIDEO_CAPTURE_DEVICE_RS_WIN_NULL_H_
+#define MEDIA_CAPTURE_VIDEO_WIN_VIDEO_CAPTURE_DEVICE_RS_WIN_NULL_H_
+
+#include "base/threading/non_thread_safe.h"
+#include "media/base/media_export.h"
+#include "media/capture/video/video_capture_device.h"
+
+namespace media {
+
+// The NULL implementation of VideoCaptureDevice.
+class MEDIA_EXPORT VideoCaptureDeviceRSWin : public base::NonThreadSafe,
+                                             public VideoCaptureDevice {
+ public:
+  explicit VideoCaptureDeviceRSWin(const Name& device_name) {}
+  ~VideoCaptureDeviceRSWin() override {}
+
+  // Opens the device driver for this device.
+  bool Init() { return false; }
+
+  // VideoCaptureDevice implementation.
+  void AllocateAndStart(const VideoCaptureParams& params,
+                        scoped_ptr<Client> client) override {}
+  void StopAndDeAllocate() override {}
+
+  // Utiliies used by VideoCaptureDeviceFactoryWin.
+  static bool IsSupported();
+  static void GetDeviceNames(Names* device_names);
+  static void GetDeviceSupportedFormats(const Name& device,
+                                        VideoCaptureFormats* formats);
+ private:
+  DISALLOW_IMPLICIT_CONSTRUCTORS(VideoCaptureDeviceRSWin);
+};
+
+}  // namespace media
+
+#endif  // MEDIA_CAPTURE_VIDEO_WIN_VIDEO_CAPTURE_DEVICE_RS_WIN_NULL_H_

--- a/media/media.gyp
+++ b/media/media.gyp
@@ -11,6 +11,8 @@
     # (DT_NEEDED) instead of using dlopen. This helps with automated
     # detection of ABI mismatches and prevents silent errors.
     'linux_link_pulseaudio%': 0,
+    # Option for Windows to use RSSDK for video capture.
+    'use_rssdk%': 0,
     'conditions': [
       # Enable ALSA and Pulse for runtime selection.
       ['(OS=="linux" or OS=="freebsd" or OS=="solaris") and (embedded!=1 or (chromecast==1 and target_arch!="arm"))', {
@@ -1027,6 +1029,23 @@
           'conditions': [
             ['target_arch=="x64"', {
               'msvs_disabled_warnings': [ 4267, ],
+            }],
+            ['use_rssdk==1', {
+              'defines': [
+                'USE_RSSDK',
+              ],
+              'dependencies': [
+                '../third_party/libpxc/libpxc.gyp:libpxc',
+              ],
+              'sources': [
+                'capture/video/win/video_capture_device_rs_win.cc',
+                'capture/video/win/video_capture_device_rs_win.h',
+              ],
+            }, {  # else use_rssdk==0
+              'sources': [
+                'capture/video/win/video_capture_device_rs_win_null.cc',
+                'capture/video/win/video_capture_device_rs_win_null.h',
+              ],
             }],
           ],
         }],


### PR DESCRIPTION
Add Intel RSSDK based video capture device VideoCaptureDeviceRSWin.

It allows:
1. Crosswalk apps are able to share the RealSense camera with other
   native apps simultaneously.
2. Crosswalk apps are able to use getUserMedia API to preview RealSense
   camera in real-time while accessing RSSDK middlewares in Crosswalk
   extensions simultaneously.

This feature is behind --use-rs-video-capture flag.

TEST=
On a device with RealSense camera and RSSDK, execute
1. DF_RawStreams.exe (RSSDK sample)
2. xwalk.exe --use-rs-video-capture
   https://webrtc.github.io/samples/src/content/devices/input-output/
Crosswalk and DF_RawStreams.exe should capture video frame from
RealSense camera simultaneously.

BUG=XWALK-6028