### PR TITLE
[Backport] Conditionally set CREATE_BREAKAWAY_FROM_JOB when job objects are used.

### DIFF
--- a/base/process/launch_win.cc
+++ b/base/process/launch_win.cc
@@ -272,8 +272,10 @@ Process LaunchProcess(const string16& cmdline,
 
     // If this code is run under a debugger, the launched process is
     // automatically associated with a job object created by the debugger.
-    // The CREATE_BREAKAWAY_FROM_JOB flag is used to prevent this.
-    flags |= CREATE_BREAKAWAY_FROM_JOB;
+    // The CREATE_BREAKAWAY_FROM_JOB flag is used to prevent this on Windows
+    // releases that do not support nested jobs.
+    if (win::GetVersion() < win::VERSION_WIN8)
+      flags |= CREATE_BREAKAWAY_FROM_JOB;
   }
 
   if (options.force_breakaway_from_job_)


### PR DESCRIPTION
Backported so that we can launch our Windows bots from the Windows Task
Scheduler. Original commit message:

> This bit of code was added in 2010 by commit 66ae36fec ("Restricting
> lifetime of python sync server on Windows via a JobObject"). The
> rationale at the time was that running a test case under a debugger
> would associate all new processes with the debugger's job object.
>
> Since 2010, Windows 8 and others have been releases, all of which
> support nested jobs and do not require processes to be created with
> the CREATE_BREAKAWAY_FROM_JOB. Not only that, but unconditionally
> setting that flag prevents browser tests from the Windows Task
> Scheduler at least on Windows 8 and later: the Task Scheduler creates
> a job object to launch the test(s), and calling CreateProcess() with
> that flag resulted in an access denied error (error number 5). Not
> setting it allows children processes to be created and attached to new
> job objects in addition to the Task Scheduler one.
>
> TEST=interactive_ui_tests, content_browsertests from the Windows Task
> Scheduler (set the task to only run when the user is logged in,
> otherwise the processes are launched from session 0)
> R=phajdan.jr@chromium.org,scottmg@chromium.org,maruel@chromium.org,mark@chromium.org
>
> Review URL: https://codereview.chromium.org/1546313002

BUG=XWALK-5142