### PR TITLE
[Android][ICU] Fix error always true of icu_utils

### DIFF
--- a/base/icu_alternatives_on_android/icu_utils.cc
+++ b/base/icu_alternatives_on_android/icu_utils.cc
@@ -243,7 +243,7 @@ int toLower(UChar* result, int resultLength, const UChar* src, int srcLength, bo
       Java_IcuUtils_toLowerString(env, sourceString.obj());
 
   string16 resultString = ConvertJavaStringToUTF16(java_result);
-  *error = true;
+  *error = false;
   return copy(result, resultLength, resultString.data(), resultString.size());
 }
 
@@ -268,7 +268,7 @@ int toUpper(UChar* result, int resultLength, const UChar* src, int srcLength, bo
       Java_IcuUtils_toUpperString(env, sourceString.obj());
 
   string16 resultString = ConvertJavaStringToUTF16(java_result);
-  *error = true;
+  *error = false;
   return copy(result, resultLength, resultString.data(), resultString.size());
 }
 
@@ -370,7 +370,7 @@ int32_t normalize(const UChar *source, int32_t sourceLength, int32_t options,
       Java_IcuUtils_normalize(env, sourceString.obj());
 
   string16 resultString = ConvertJavaStringToUTF16(java_result);
-  *error = true;
+  *error = false;
   return copy(result, resultLength, resultString.data(), resultString.size());
 }
 


### PR DESCRIPTION
[Android][ICU] Fix error always true of icu_utils

icu_utils.[cc|h] is the ICU JNI alternative C++ bridge, it will be enabled
by build flag "use_icu_alternatives_on_android=1". The in/out parameter *error
of functions toLower(), toUpper() and normalize() are be set true at any time.
The caller will detect that error and then drop the result.

The fix simply to set the error as false. Even the conversion failed, the
original string will be returned, which is no harm.

BUG=XWALK-6161