### PR TITLE
XWALK-4992 [windows] App does not support gamepad

### DIFF
--- a/chrome/installer/mini_installer/chrome.release
+++ b/chrome/installer/mini_installer/chrome.release
@@ -39,7 +39,6 @@ natives_blob.bin: %(VersionDir)s\
 resources.pak: %(VersionDir)s\
 snapshot_blob.bin: %(VersionDir)s\
 syzyasan_rtl.dll: %(VersionDir)s\
-xinput1_3.dll: %(VersionDir)s\
 #
 # Sub directories living in the version dir
 #

--- a/chrome/tools/build/win/FILES.cfg
+++ b/chrome/tools/build/win/FILES.cfg
@@ -382,11 +382,6 @@ FILES = [
     'buildtype': ['dev', 'official'],
     'filegroup': ['default', 'symsrc'],
   },
-  # XInput files:
-  {
-    'filename': 'xinput1_3.dll',
-    'buildtype': ['dev', 'official'],
-  },
   # Native Client plugin files:
   {
     'filename': 'nacl_irt_x86_32.nexe',

--- a/content/browser/gamepad/gamepad_platform_data_fetcher_win.h
+++ b/content/browser/gamepad/gamepad_platform_data_fetcher_win.h
@@ -49,10 +49,10 @@ class GamepadPlatformDataFetcherWin : public GamepadDataFetcher {
   typedef DWORD (WINAPI *XInputGetStateFunc)(
       DWORD dwUserIndex, XINPUT_STATE* pState);
 
-  // Get functions from dynamically loaded xinput1_3.dll. We don't use
-  // DELAYLOAD because the import library for Win8 SDK pulls xinput1_4 which
-  // isn't redistributable. Returns true if loading was successful. We include
-  // xinput1_3.dll with Chrome.
+  // Get functions from dynamically loaded xinputX_Y.dll. We don't use
+  // DELAYLOAD because XInputEnable is not available on all versions (it is
+  // marked as deprecated on Win10) and thus the symbol is resolved in runtime.
+  // Returns true if loading was successful.
   bool GetXInputDllFunctions();
 
   // Scan for connected XInput and DirectInput gamepads.
@@ -71,7 +71,6 @@ class GamepadPlatformDataFetcherWin : public GamepadDataFetcher {
 
   // Function pointers to XInput functionality, retrieved in
   // |GetXinputDllFunctions|.
-  XInputEnableFunc xinput_enable_;
   XInputGetCapabilitiesFunc xinput_get_capabilities_;
   XInputGetStateFunc xinput_get_state_;
 

--- a/content/content_common.gypi
+++ b/content/content_common.gypi
@@ -1042,30 +1042,6 @@
         '<(DEPTH)/third_party/khronos',
       ],
     }],
-    ['OS=="win" and directxsdk_exists=="True"', {
-      'actions': [
-      {
-        'action_name': 'extract_xinput',
-        'variables': {
-          'input': 'APR2007_xinput_<(winsdk_arch).cab',
-          'output': 'xinput1_3.dll',
-        },
-        'inputs': [
-          '../third_party/directxsdk/files/Redist/<(input)',
-        ],
-        'outputs': [
-          '<(PRODUCT_DIR)/<(output)',
-        ],
-        'action': [
-          'python',
-        '../build/extract_from_cab.py',
-        '..\\third_party\\directxsdk\\files\\Redist\\<(input)',
-        '<(output)',
-        '<(PRODUCT_DIR)',
-        ],
-      },
-     ]
-    }],
     ['use_seccomp_bpf==0', {
       'sources!': [
         'common/sandbox_linux/android/sandbox_bpf_base_policy_android.cc',

--- a/tools/checkbins/checkbins.py
+++ b/tools/checkbins/checkbins.py
@@ -30,8 +30,7 @@ MACHINE_TYPE_AMD64 = 0x8664
 # Windows guru for advice.
 EXCLUDED_FILES = ['chrome_frame_mini_installer.exe',
                   'mini_installer.exe',
-                  'wow_helper.exe',
-                  'xinput1_3.dll' # Microsoft DirectX redistributable.
+                  'wow_helper.exe'
                   ]
 
 def IsPEFile(path):


### PR DESCRIPTION
    XWALK-4992 [windows] App does not support gamepad

    While chromium is bundling xinput1_3.dll from DirectX redist, using whatever
    platform suports. Logic about what dll is in use for different platforms is
    copied from Xinput.h.
    In order to target all of the Windows versions with the same binary, chosen to
    keep dynamic linking approach. Otherwise, there would be a problem with
    XInputEnable not available in xinput dll before Windows8 and deprecated on
    Windows 10.

    Snippet from <ProgramFiles>\Windows Kits\10\Include\10.0.10586.0\um\Xinput.h:

    #if(_WIN32_WINNT >= _WIN32_WINNT_WIN8)
    #define XINPUT_DLL_A  "xinput1_4.dll"
    #define XINPUT_DLL_W L"xinput1_4.dll"
    #else
    #define XINPUT_DLL_A  "xinput9_1_0.dll"
    #define XINPUT_DLL_W L"xinput9_1_0.dll"
    #endif

    For detailed information on Windows library loading and search path priorities,
    check https://msdn.microsoft.com documentation on LoadLibrary().