### PR TITLE
[Blink] WebCL: Only set ENABLE_WEBCL in the relevant files.

### DIFF
--- a/third_party/WebKit/Source/build/features.gypi
+++ b/third_party/WebKit/Source/build/features.gypi
@@ -52,6 +52,9 @@
       'detailed_memory_infra%': 0,
       'blink_logging_always_on%': 0,
       'link_core_modules_separately%': 1,
+
+      # WebCL support in Crosswalk.
+      'enable_webcl%': 0,
     },
     'conditions': [
       ['use_concatenated_impulse_responses==1', {
@@ -101,6 +104,12 @@
       ['link_core_modules_separately==1 and component=="shared_library"', {
         'feature_defines': [
           'LINK_CORE_MODULES_SEPARATELY',
+        ],
+      }],
+
+      ['enable_webcl==1', {
+        'feature_defines': [
+          'ENABLE_WEBCL=1',
         ],
       }],
     ],


### PR DESCRIPTION
This change (together with a follow-up in the Crosswalk repository
itself) moves the definition of the ENABLE_WEBCL macro to Blink's
features.gypi, so that it is only passed to the relevant modules and
bindings files intead of all the 15000+ files part of Crosswalk's build.

This part of the fix only adds the definition to the Blink side; the
Crosswalk patch will stop defining the macro for the other files.