### PR TITLE
[Android][ICU] Add Shift-JIS codec support.

### DIFF
--- a/third_party/WebKit/Source/wtf/text/TextCodecICUAlternatives.cpp
+++ b/third_party/WebKit/Source/wtf/text/TextCodecICUAlternatives.cpp
@@ -1,0 +1,69 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "config.h"
+#include "wtf/text/TextCodecICUAlternatives.h"
+#include "wtf/PassOwnPtr.h"
+#include "wtf/text/CharacterNames.h"
+#include "wtf/text/WTFString.h"
+#include "base/icu_alternatives_on_android/icu_utils.h"
+
+namespace WTF {
+
+TextCodecICUAlternatives::TextCodecICUAlternatives(const TextEncoding& encoding)
+    : m_encoding(encoding)
+{
+}
+
+void TextCodecICUAlternatives::registerEncodingNames(EncodingNameRegistrar registrar)
+{
+    //TODO, add more charsets supported by Java.
+    registrar("Shift-JIS", "Shift-JIS");
+}
+
+PassOwnPtr<TextCodec> TextCodecICUAlternatives::create(const TextEncoding& encoding, const void*)
+{
+    return adoptPtr(new TextCodecICUAlternatives(encoding));
+}
+
+void TextCodecICUAlternatives::registerCodecs(TextCodecRegistrar registrar)
+{
+    registrar("Shift-JIS", create, 0);
+}
+
+String TextCodecICUAlternatives::decode(const char* bytes, size_t length, FlushBehavior flush, bool stopOnError, bool& sawError)
+{ 
+    if(!bytes || !length)
+        return String();  
+    bool result = false;
+    const std::string encoded(bytes);
+    int on_error = 0; //stop on error.
+    if (!stopOnError) 
+        on_error = 1; //skip on error.
+    const char* codepage = m_encoding.name();
+    base::string16 utf16;
+    result = base::icu_utils::DecodeCodePage(codepage, encoded, on_error, &utf16);
+    sawError = !result;
+    return String(utf16.data());
+}
+
+CString TextCodecICUAlternatives::encode(const UChar* characters, size_t length, UnencodableHandling)
+{
+   if (!characters || !length)
+       return CString();
+   bool result = false;
+   base::string16 utf16(characters, length);
+   std::string encoded;
+   result = base::icu_utils::EncodeCodePage(m_encoding.name(), utf16, 0, &encoded);
+   if (!result)
+      return CString();
+   return CString(encoded.c_str());    
+}
+CString TextCodecICUAlternatives::encode(const LChar* characters, size_t length, UnencodableHandling)
+{
+    //CharsetEncoder only accept sixteen-bit Unicode characters as legal input. 
+    return CString();
+}
+
+} // namespace WTF

--- a/third_party/WebKit/Source/wtf/text/TextCodecICUAlternatives.h
+++ b/third_party/WebKit/Source/wtf/text/TextCodecICUAlternatives.h
@@ -1,0 +1,32 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TextCodecICUAlternatives_h
+#define TextCodecICUAlternatives_h
+
+#include "wtf/text/TextCodec.h"
+#include "wtf/text/TextEncoding.h"
+
+namespace WTF {
+
+class TextCodecICUAlternatives final : public TextCodec {
+public:
+    TextCodecICUAlternatives(const TextEncoding&);
+    static void registerEncodingNames(EncodingNameRegistrar);
+    static void registerCodecs(TextCodecRegistrar);
+
+private: 
+    static PassOwnPtr<TextCodec> create(const TextEncoding&, const void*);
+
+    virtual String decode(const char* bytes, size_t length, FlushBehavior flush, bool stopOnError, bool& sawError) override;
+
+    virtual CString encode(const UChar* characters, size_t length, UnencodableHandling) override;
+    virtual CString encode(const LChar* characters, size_t length, UnencodableHandling) override;
+
+    TextEncoding m_encoding;
+};
+
+} // namespace WTF
+
+#endif // TextCodecICUAlternatives_h

--- a/third_party/WebKit/Source/wtf/text/TextEncodingRegistry.cpp
+++ b/third_party/WebKit/Source/wtf/text/TextEncodingRegistry.cpp
@@ -44,6 +44,9 @@
 #include "wtf/text/TextCodecUserDefined.h"
 #include "wtf/text/TextEncoding.h"
 
+#if defined(USE_ICU_ALTERNATIVES_ON_ANDROID)
+#include "wtf/text/TextCodecICUAlternatives.h"
+#endif
 namespace WTF {
 
 const size_t maxEncodingNameLength = 63;
@@ -250,6 +253,9 @@ static void extendTextCodecMaps()
 #if !defined(USE_ICU_ALTERNATIVES_ON_ANDROID)
     TextCodecICU::registerEncodingNames(addToTextEncodingNameMap);
     TextCodecICU::registerCodecs(addToTextCodecMap);
+#else
+    TextCodecICUAlternatives::registerEncodingNames(addToTextEncodingNameMap);
+    TextCodecICUAlternatives::registerCodecs(addToTextCodecMap);
 #endif
 
     pruneBlacklistedCodecs();

--- a/third_party/WebKit/Source/wtf/wtf.gyp
+++ b/third_party/WebKit/Source/wtf/wtf.gyp
@@ -115,6 +115,9 @@
           'sources!': [
             'text/TextCodecICU.cpp',
           ],
+          'sources': [
+            'text/TextCodecICUAlternatives.cpp',
+          ],
           'dependencies': [
             '<(DEPTH)/base/base.gyp:base_icu_alternatives',
           ],


### PR DESCRIPTION
The "use_icu_alternatives_on_android=1" flag cut off the icu c++
library, which breaks the Shift-JIS encode and decode functions.
So we add a TextCodecICUAlternatives class which provides such
functions by using the Java class CharsetEncoder and
CharsetDecoder.

BUG=XWALK-6175