### PR TITLE
[Lite] [WORKAROUND] One assert always blocks debug

### DIFF
--- a/gpu/command_buffer/service/program_manager.cc
+++ b/gpu/command_buffer/service/program_manager.cc
@@ -1107,7 +1107,7 @@ bool Program::DetectShaderVersionMismatch() const {
         return true;
       }
       version = shader->shader_version();
-      DCHECK(version != Shader::kUndefinedShaderVersion);
+      //DCHECK(version != Shader::kUndefinedShaderVersion);
     }
   }
   return false;


### PR DESCRIPTION
This Assert() blocks debugging. Only happens in debugging build,
not in release build. So just remove it.

It is just a workaround for debugging convenience, we won't port
it to next release version.