### PR TITLE
Revert "Provide a ScreenOrientationDispatcherHost getter."

### DIFF
--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -720,10 +720,6 @@ const GURL& WebContentsImpl::GetLastCommittedURL() const {
   return entry ? entry->GetVirtualURL() : GURL::EmptyGURL();
 }
 
-ScreenOrientationDispatcherHost* WebContentsImpl::GetScreenOrientationDispatcherHost() {
-  return screen_orientation_dispatcher_host_.get();
-}
-
 WebContentsDelegate* WebContentsImpl::GetDelegate() {
   return delegate_;
 }

--- a/content/browser/web_contents/web_contents_impl.h
+++ b/content/browser/web_contents/web_contents_impl.h
@@ -225,7 +225,6 @@ class CONTENT_EXPORT WebContentsImpl
   void RequestAXTreeSnapshot(AXTreeSnapshotCallback callback);
 
   // WebContents ------------------------------------------------------
-  ScreenOrientationDispatcherHost* GetScreenOrientationDispatcherHost() override;
   WebContentsDelegate* GetDelegate() override;
   void SetDelegate(WebContentsDelegate* delegate) override;
   NavigationControllerImpl& GetController() override;

--- a/content/public/browser/web_contents.h
+++ b/content/public/browser/web_contents.h
@@ -53,7 +53,6 @@ class RenderFrameHost;
 class RenderProcessHost;
 class RenderViewHost;
 class RenderWidgetHostView;
-class ScreenOrientationDispatcherHost;
 class SiteInstance;
 class WebContentsDelegate;
 struct CustomContextMenuContext;
@@ -173,8 +172,6 @@ class WebContents : public PageNavigator,
   ~WebContents() override {}
 
   // Intrinsic tab state -------------------------------------------------------
-
-  virtual ScreenOrientationDispatcherHost* GetScreenOrientationDispatcherHost() = 0;
 
   // Gets/Sets the delegate.
   virtual WebContentsDelegate* GetDelegate() = 0;


### PR DESCRIPTION
This reverts commit dddd14d2ca1040128d41dff9c5391efd0a267633.

This change was only used by the Tizen port, which got removed last
year.