### PR TITLE
Page Visibility API: visibilitychange on Windows screen lock/unlock

### DIFF
--- a/ui/views/controls/native/native_view_host.cc
+++ b/ui/views/controls/native/native_view_host.cc
@@ -127,6 +127,22 @@ void NativeViewHost::VisibilityChanged(View* starting_from, bool is_visible) {
   Layout();
 }
 
+void NativeViewHost::OnSoftVisibilityChanged(bool visible) {
+  if (!native_view_ || !native_wrapper_.get())
+    return;
+
+  if (GetVisibleBounds().IsEmpty())
+    return;
+
+  // If the widget wasn't .e.g. minimized, hide and show would trigger
+  // PageVisibility API, enabling JS to save power while screen is locked.
+  if (visible) {
+    Layout();
+  } else {
+    native_wrapper_->HideWidget();
+  }
+}
+
 bool NativeViewHost::GetNeedsNotificationWhenVisibleBoundsChange() const {
   // The native widget is placed relative to the root. As such, we need to
   // know when the position of any ancestor changes, or our visibility relative

--- a/ui/views/controls/native/native_view_host.h
+++ b/ui/views/controls/native/native_view_host.h
@@ -82,6 +82,7 @@ class VIEWS_EXPORT NativeViewHost : public View {
   void OnFocus() override;
   gfx::NativeViewAccessible GetNativeViewAccessible() override;
   gfx::NativeCursor GetCursor(const ui::MouseEvent& event) override;
+  void OnSoftVisibilityChanged(bool visible) override;
 
  protected:
   bool GetNeedsNotificationWhenVisibleBoundsChange() const override;

--- a/ui/views/view.cc
+++ b/ui/views/view.cc
@@ -1840,6 +1840,12 @@ void View::PropagateNativeThemeChanged(const ui::NativeTheme* theme) {
   OnNativeThemeChanged(theme);
 }
 
+void View::PropagateSoftVisibilityChanged(bool visible) {
+  for (int i = 0, count = child_count(); i < count; ++i)
+    child_at(i)->PropagateSoftVisibilityChanged(visible);
+  OnSoftVisibilityChanged(visible);
+}
+
 // Size and disposition --------------------------------------------------------
 
 void View::PropagateVisibilityNotifications(View* start, bool is_visible) {

--- a/ui/views/view.h
+++ b/ui/views/view.h
@@ -1073,6 +1073,8 @@ class VIEWS_EXPORT View : public ui::LayerDelegate,
   // FocusManager manages this view.
   virtual void NativeViewHierarchyChanged();
 
+  virtual void OnSoftVisibilityChanged(bool visible) {}
+
   // Painting ------------------------------------------------------------------
 
   // Responsible for calling Paint() on child Views. Override to control the
@@ -1275,6 +1277,8 @@ class VIEWS_EXPORT View : public ui::LayerDelegate,
   // Registers/unregisters accelerators as necessary and calls
   // VisibilityChanged().
   void VisibilityChangedImpl(View* starting_from, bool is_visible);
+
+  void PropagateSoftVisibilityChanged(bool visible);
 
   // Responsible for propagating bounds change notifications to relevant
   // views.

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
@@ -780,6 +780,10 @@ void DesktopWindowTreeHostWin::HandleVisibilityChanged(bool visible) {
   native_widget_delegate_->OnNativeWidgetVisibilityChanged(visible);
 }
 
+void DesktopWindowTreeHostWin::HandleSoftVisibilityChanged(bool visible) {
+  native_widget_delegate_->OnSoftVisibilityChanged(visible);
+}
+
 void DesktopWindowTreeHostWin::HandleClientSizeChanged(
     const gfx::Size& new_size) {
   if (dispatcher())

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
@@ -191,6 +191,7 @@ class VIEWS_EXPORT DesktopWindowTreeHostWin
   bool HandleScrollEvent(const ui::ScrollEvent& event) override;
   void HandleWindowSizeChanging() override;
   void HandleWindowSizeChanged() override;
+  void HandleSoftVisibilityChanged(bool visible) override;
 
   Widget* GetWidget();
   const Widget* GetWidget() const;

--- a/ui/views/widget/native_widget_delegate.h
+++ b/ui/views/widget/native_widget_delegate.h
@@ -67,6 +67,14 @@ class VIEWS_EXPORT NativeWidgetDelegate {
   // Called when the window is shown/hidden.
   virtual void OnNativeWidgetVisibilityChanged(bool visible) = 0;
 
+  // Some OSs (e.g. Windows and Linux) don't mark windows as hiden on screen
+  // lock or when other opaque windows fully cover them.
+  // Note that e.g. OSX and Android do this while Windows and Linux don't.
+  // OnSoftVisibilityChanged enables that OS window state is kept as is (on
+  // Linux and Windows) and that e.g. power saving PageVisibility API is still
+  // properly triggered.
+  virtual void OnSoftVisibilityChanged(bool visible) = 0;
+
   // Called when the native widget is created.
   // The |desktop_widget| bool is true for widgets created in the desktop and
   // false for widgets created in the shell.

--- a/ui/views/widget/widget.cc
+++ b/ui/views/widget/widget.cc
@@ -1086,6 +1086,11 @@ void Widget::OnNativeWidgetVisibilityChanged(bool visible) {
     root->layer()->SetVisible(visible);
 }
 
+void Widget::OnSoftVisibilityChanged(bool visible) {
+  if (View* root = GetRootView())
+    root->PropagateSoftVisibilityChanged(visible);
+}
+
 void Widget::OnNativeWidgetCreated(bool desktop_widget) {
   if (is_top_level())
     focus_manager_.reset(FocusManagerFactory::Create(this, desktop_widget));

--- a/ui/views/widget/widget.h
+++ b/ui/views/widget/widget.h
@@ -775,6 +775,7 @@ class VIEWS_EXPORT Widget : public internal::NativeWidgetDelegate,
   void OnNativeBlur() override;
   void OnNativeWidgetVisibilityChanging(bool visible) override;
   void OnNativeWidgetVisibilityChanged(bool visible) override;
+  void OnSoftVisibilityChanged(bool visible) override;
   void OnNativeWidgetCreated(bool desktop_widget) override;
   void OnNativeWidgetDestroying() override;
   void OnNativeWidgetDestroyed() override;

--- a/ui/views/win/hwnd_message_handler.cc
+++ b/ui/views/win/hwnd_message_handler.cc
@@ -2247,8 +2247,14 @@ void HWNDMessageHandler::OnWindowPosChanged(WINDOWPOS* window_pos) {
 void HWNDMessageHandler::OnSessionChange(WPARAM status_code) {
   // Direct3D presents are ignored while the screen is locked, so force the
   // window to be redrawn on unlock.
-  if (status_code == WTS_SESSION_UNLOCK)
+  if (status_code == WTS_SESSION_UNLOCK) {
     ForceRedrawWindow(10);
+    if (IsVisible())
+      delegate_->HandleSoftVisibilityChanged(true);
+  } else if (status_code == WTS_SESSION_LOCK) {
+    if (IsVisible())
+      delegate_->HandleSoftVisibilityChanged(false);
+  }
 }
 
 void HWNDMessageHandler::HandleTouchEvents(const TouchEvents& touch_events) {

--- a/ui/views/win/hwnd_message_handler_delegate.h
+++ b/ui/views/win/hwnd_message_handler_delegate.h
@@ -149,6 +149,12 @@ class VIEWS_EXPORT HWNDMessageHandlerDelegate {
   // Called when the window's visibility changed. |visible| holds the new state.
   virtual void HandleVisibilityChanged(bool visible) = 0;
 
+  // Called when the "calculated" window's visibility changed.
+  // OS doesn't mark windows hidden on screen lock or when other opaque windows
+  // cover them.
+  // |visible| holds the new state.
+  virtual void HandleSoftVisibilityChanged(bool visible) = 0;
+
   // Called when the window's client size changed. |new_size| holds the new
   // size.
   virtual void HandleClientSizeChanged(const gfx::Size& new_size) = 0;


### PR DESCRIPTION
BUG=XWALK-5503

Some OSs (e.g. Windows and Linux) don't mark windows as hidden on screen
lock or when other opaque windows fully cover them.
Note that e.g. OSX and Android do this while Windows and Linux don't.
OnSoftVisibilityChanged enables that OS window state is kept as is (on
Linux and Windows) and that e.g. power saving PageVisibility API is still
properly triggered.

The first patch here targets Windows and screen lock.