### PR TITLE
Screen orientation lock implementation for Windows

### DIFF
--- a/content/browser/browser_main_loop.cc
+++ b/content/browser/browser_main_loop.cc
@@ -126,7 +126,9 @@
 #include <shellapi.h>
 
 #include "base/memory/memory_pressure_monitor_win.h"
+#include "base/win/windows_version.h"
 #include "content/browser/system_message_window_win.h"
+#include "content/browser/screen_orientation/screen_orientation_delegate_win.h"
 #include "content/common/sandbox_win.h"
 #include "net/base/winsock_init.h"
 #include "ui/base/l10n/l10n_util_win.h"
@@ -578,6 +580,8 @@ void BrowserMainLoop::PostMainMessageLoopStart() {
 
 #if defined(OS_WIN)
   system_message_window_.reset(new SystemMessageWindowWin);
+  if (base::win::GetVersion() >= base::win::VERSION_WIN8)
+    screen_orientation_delegate_.reset(new ScreenOrientationDelegateWin());
 #endif
 
   // TODO(boliu): kSingleProcess check is a temporary workaround for

--- a/content/browser/browser_main_loop.h
+++ b/content/browser/browser_main_loop.h
@@ -69,6 +69,7 @@ class DeviceMonitorLinux;
 class DeviceMonitorMac;
 #elif defined(OS_WIN)
 class SystemMessageWindowWin;
+class ScreenOrientationDelegate;
 #endif
 
 // Implements the main browser loop stages called from BrowserMainRunner.
@@ -198,6 +199,7 @@ class CONTENT_EXPORT BrowserMainLoop {
       system_stats_monitor_;
 
 #if defined(OS_WIN)
+  scoped_ptr<ScreenOrientationDelegate> screen_orientation_delegate_;
   scoped_ptr<SystemMessageWindowWin> system_message_window_;
 #endif
 

--- a/content/browser/screen_orientation/screen_orientation_delegate_win.cc
+++ b/content/browser/screen_orientation/screen_orientation_delegate_win.cc
@@ -1,0 +1,129 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/browser/screen_orientation/screen_orientation_delegate_win.h"
+
+#include <windows.h>
+#include "content/public/browser/screen_orientation_provider.h"
+
+namespace content {
+
+ScreenOrientationDelegateWin::ScreenOrientationDelegateWin() {
+  content::ScreenOrientationProvider::SetDelegate(this);
+}
+
+ScreenOrientationDelegateWin::~ScreenOrientationDelegateWin() {
+  content::ScreenOrientationProvider::SetDelegate(nullptr);
+}
+
+bool ScreenOrientationDelegateWin::FullScreenRequired(
+    content::WebContents* web_contents) {
+  return false;
+}
+
+// SetDisplayAutoRotationPreferences is available on Windows 8 and after.
+static void SetDisplayAutoRotationPreferencesWrapper(
+  ORIENTATION_PREFERENCE orientation) {
+  typedef void(WINAPI *SetDisplayAutoRotationPreferencesPtr)(
+    ORIENTATION_PREFERENCE);
+  static SetDisplayAutoRotationPreferencesPtr
+    set_display_auto_rotation_preferences_func =
+    reinterpret_cast<SetDisplayAutoRotationPreferencesPtr>(
+    GetProcAddress(GetModuleHandleA("user32.dll"),
+    "SetDisplayAutoRotationPreferences"));
+  if (set_display_auto_rotation_preferences_func)
+    set_display_auto_rotation_preferences_func(orientation);
+}
+
+// GetAutoRotationState is available on Windows 8 and after.
+static BOOL GetAutoRotationStateWrapper(PAR_STATE pState) {
+  typedef BOOL(WINAPI *GetAutoRotationStatePtr)(PAR_STATE);
+  static GetAutoRotationStatePtr get_auto_rotation_state_func =
+    reinterpret_cast<GetAutoRotationStatePtr>(
+    GetProcAddress(GetModuleHandleA("user32.dll"),
+    "GetAutoRotationState"));
+  if (get_auto_rotation_state_func)
+    return get_auto_rotation_state_func(pState);
+  return FALSE;
+}
+
+static void GetCurrentDisplaySettings(bool *landscape, bool *flipped) {
+  DEVMODE dm;
+  ZeroMemory(&dm, sizeof(dm));
+  dm.dmSize = sizeof(dm);
+  if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &dm))
+    return;
+  if (flipped) {
+    *flipped = (dm.dmDisplayOrientation == DMDO_270
+                || dm.dmDisplayOrientation == DMDO_180);
+  }
+  if (landscape)
+    *landscape = (dm.dmPelsWidth > dm.dmPelsHeight);
+}
+
+void ScreenOrientationDelegateWin::Lock(
+  content::WebContents* web_contents,
+  blink::WebScreenOrientationLockType lock_orientation) {
+  ORIENTATION_PREFERENCE prefs = ORIENTATION_PREFERENCE_NONE;
+  bool landscape = true;
+  bool flipped = false;
+  switch (lock_orientation) {
+  case blink::WebScreenOrientationLockPortraitPrimary:
+    prefs = ORIENTATION_PREFERENCE_PORTRAIT;
+    break;
+  case blink::WebScreenOrientationLockPortraitSecondary:
+    prefs = ORIENTATION_PREFERENCE_PORTRAIT_FLIPPED;
+    break;
+  case blink::WebScreenOrientationLockLandscapePrimary:
+    prefs = ORIENTATION_PREFERENCE_LANDSCAPE;
+    break;
+  case blink::WebScreenOrientationLockLandscapeSecondary:
+    prefs = ORIENTATION_PREFERENCE_LANDSCAPE_FLIPPED;
+    break;
+  case blink::WebScreenOrientationLockPortrait:
+    GetCurrentDisplaySettings(&landscape, &flipped);
+    prefs = (flipped && !landscape) ? ORIENTATION_PREFERENCE_PORTRAIT_FLIPPED
+                                    : ORIENTATION_PREFERENCE_PORTRAIT;
+    break;
+  case blink::WebScreenOrientationLockLandscape:
+    GetCurrentDisplaySettings(&landscape, &flipped);
+    prefs = (flipped && landscape) ? ORIENTATION_PREFERENCE_LANDSCAPE_FLIPPED
+                                   : ORIENTATION_PREFERENCE_LANDSCAPE;
+    break;
+  case blink::WebScreenOrientationLockNatural:
+    GetCurrentDisplaySettings(&landscape, &flipped);
+    prefs = landscape ? ORIENTATION_PREFERENCE_LANDSCAPE
+                      : ORIENTATION_PREFERENCE_PORTRAIT;
+    break;
+  case blink::WebScreenOrientationLockAny:
+    GetCurrentDisplaySettings(&landscape, &flipped);
+    if (landscape) {
+      prefs = flipped ? ORIENTATION_PREFERENCE_LANDSCAPE_FLIPPED
+                      : ORIENTATION_PREFERENCE_LANDSCAPE;
+    } else {
+      prefs = flipped ? ORIENTATION_PREFERENCE_PORTRAIT_FLIPPED
+                      : ORIENTATION_PREFERENCE_PORTRAIT;
+    }
+    break;
+  case blink::WebScreenOrientationLockDefault:
+  default:
+    break;
+  }
+  SetDisplayAutoRotationPreferencesWrapper(prefs);
+}
+
+bool ScreenOrientationDelegateWin::ScreenOrientationProviderSupported() {
+  AR_STATE autoRotationState;
+  ZeroMemory(&autoRotationState, sizeof(AR_STATE));
+  return (GetAutoRotationStateWrapper(&autoRotationState)
+          && !(autoRotationState & AR_NOSENSOR)
+          && !(autoRotationState & AR_NOT_SUPPORTED));
+}
+
+void ScreenOrientationDelegateWin::Unlock(
+    content::WebContents* web_contents) {
+  SetDisplayAutoRotationPreferencesWrapper(ORIENTATION_PREFERENCE_NONE);
+}
+
+}  // namespace content

--- a/content/browser/screen_orientation/screen_orientation_delegate_win.h
+++ b/content/browser/screen_orientation/screen_orientation_delegate_win.h
@@ -1,0 +1,31 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CONTENT_BROWSER_SCREEN_ORIENTATION_SCREEN_ORIENTATION_DELEGATE_WIN_H_
+#define CONTENT_BROWSER_SCREEN_ORIENTATION_SCREEN_ORIENTATION_DELEGATE_WIN_H_
+
+#include "content/public/browser/screen_orientation_delegate.h"
+
+namespace content {
+
+class ScreenOrientationDelegateWin
+    : public content::ScreenOrientationDelegate {
+ public:
+  ScreenOrientationDelegateWin();
+  ~ScreenOrientationDelegateWin() override;
+
+ private:
+  // content::ScreenOrientationDelegate:
+  bool FullScreenRequired(content::WebContents* web_contents) override;
+  void Lock(content::WebContents* web_contents,
+            blink::WebScreenOrientationLockType lock_orientation) override;
+  bool ScreenOrientationProviderSupported() override;
+  void Unlock(content::WebContents* web_contents) override;
+
+  DISALLOW_COPY_AND_ASSIGN(ScreenOrientationDelegateWin);
+};
+
+}  // namespace content
+
+#endif  // CONTENT_BROWSER_SCREEN_ORIENTATION_SCREEN_ORIENTATION_DELEGATE_WIN_H_

--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -74,6 +74,9 @@ static void SetRuntimeFeatureDefaultsForPlatform() {
     WebRuntimeFeatures::enableNetworkInformation(false);
 #endif
 
+/*
+// TODO (astojilj) - this is removed in latest chromium. commented here
+// in order to enable screen orientation api.
 #if defined(OS_WIN)
   // Screen Orientation API is currently broken on Windows 8 Metro mode and
   // until we can find how to disable it only for Blink instances running in a
@@ -84,7 +87,7 @@ static void SetRuntimeFeatureDefaultsForPlatform() {
       version == base::win::VERSION_WIN8_1) {
     WebRuntimeFeatures::enableScreenOrientation(false);
   }
-#endif // OS_WIN
+#endif // OS_WIN*/
 }
 
 void SetRuntimeFeaturesDefaultsAndUpdateFromArgs(

--- a/content/content_browser.gypi
+++ b/content/content_browser.gypi
@@ -1294,6 +1294,8 @@
       'browser/resource_context_impl.h',
       'browser/safe_util_win.cc',
       'browser/safe_util_win.h',
+      'browser/screen_orientation/screen_orientation_delegate_win.cc',
+      'browser/screen_orientation/screen_orientation_delegate_win.h',
       'browser/screen_orientation/screen_orientation_dispatcher_host_impl.cc',
       'browser/screen_orientation/screen_orientation_dispatcher_host_impl.h',
       'browser/service_worker/embedded_worker_instance.cc',


### PR DESCRIPTION
BUG=XWALK-5002

[windows] App does not support orientation lock

This patch implements Screen orientation lock API for Windows.

Note: On Windows 8 and later, fullscreen is not mandatory to get application
prefered locking - so API works regardless if it is in fullscreen mode or not.
