### PR TITLE
[Android] Add SetBackgroundColor to avoid white screen on startup

### DIFF
--- a/content/browser/android/content_view_core_impl.cc
+++ b/content/browser/android/content_view_core_impl.cc
@@ -1332,6 +1332,11 @@ jint ContentViewCoreImpl::GetCurrentRenderProcessId(JNIEnv* env, jobject obj) {
       web_contents_->GetRenderViewHost());
 }
 
+void ContentViewCoreImpl::SetBackgroundColor(JNIEnv* env, jobject jobj,
+    jint color) {
+    root_layer_->SetBackgroundColor(color);
+}
+
 void ContentViewCoreImpl::SetBackgroundOpaque(JNIEnv* env, jobject jobj,
     jboolean opaque) {
   if (GetRenderWidgetHostViewAndroid()) {

--- a/content/public/android/java/src/org/chromium/content/browser/ContentViewCore.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ContentViewCore.java
@@ -3256,6 +3256,12 @@ public class ContentViewCore implements AccessibilityStateChangeListener, Screen
         mSmartClipDataListener = listener;
     }
 
+    public void setBackgroundColor(int color) {
+        if (mNativeContentViewCore != 0) {
+            nativeSetBackgroundColor(mNativeContentViewCore, color);
+        }
+    }
+
     public void setBackgroundOpaque(boolean opaque) {
         if (mNativeContentViewCore != 0) {
             nativeSetBackgroundOpaque(mNativeContentViewCore, opaque);
@@ -3469,6 +3475,8 @@ public class ContentViewCore implements AccessibilityStateChangeListener, Screen
 
     private native void nativeExtractSmartClipData(long nativeContentViewCoreImpl,
             int x, int y, int w, int h);
+
+    private native void nativeSetBackgroundColor(long nativeContentViewCoreImpl, int color);
 
     private native void nativeSetBackgroundOpaque(long nativeContentViewCoreImpl, boolean opaque);
 }


### PR DESCRIPTION
If set the WindowBackground of Activity to RED, and webpage page's backgroudn to RED,
when application starts or resumes after click back key, it will showup a white screen
shortly. With this SetBackgroundColor, we can change the first screen to a specified color,
which can help to avoid white screen.

Related BUG=XWALK-4809, XWALK-4995