### PR TITLE
Suppress lint warning.

### DIFF
--- a/build/android/lint/suppressions.xml
+++ b/build/android/lint/suppressions.xml
@@ -41,7 +41,7 @@ Still reading?
   <issue id="HandlerLeak">
     <ignore path="remoting/android/java/src/org/chromium/chromoting/TapGestureDetector.java"/>
   </issue>
-  <issue id="IconMissingDensityFolder">
+  <issue id="IconMissingDensityFolder" severity="ignore">
     <!-- see crbug.com/542435 -->
     <ignore path="android_webview/apk/java/res" />
   </issue>
@@ -101,7 +101,7 @@ Still reading?
     <ignore path="content/public/android/java/src/org/chromium/content/browser/MediaResourceGetter.java"/>
   </issue>
   <issue id="SetJavaScriptEnabled" severity="ignore"/>
-  <issue id="UnusedResources">
+  <issue id="UnusedResources" severity="ignore">
     <!-- Used by chrome/android/java/AndroidManifest.xml -->
     <ignore path="chrome/android/java/res/drawable/window_background.xml" />
     <ignore path="chrome/android/java/res/xml/bookmark_thumbnail_widget_info.xml" />


### PR DESCRIPTION
This patch is to suppress the lint warnings for missing density folder
and unused resources.
The exactly way is to add the ignore path to specified list, e.g.
  <issue id="UnusedResources">
    <ignore path="xwalk/app/android/app_hello_world/res/values/strings.xml" />
  </issue>
but this way does not work all the time, I have tracked the command line,
python code and config xml, there is no difference.

Ignore all the warnings for missing density folder and unused resources
as a temporary solution.

BUG=XWALK-6276