### PR TITLE
[Lite] Set aapt to do compressing on all the apk contents.

### DIFF
--- a/build/java_apk.gypi
+++ b/build/java_apk.gypi
@@ -94,7 +94,7 @@
     'is_test_apk%': 0,
     # Allow icu data, v8 snapshots, and pak files to be loaded directly from the .apk.
     # Note: These are actually suffix matches, not necessarily extensions.
-    'extensions_to_not_compress%': '.dat,.bin,.pak',
+    'extensions_to_not_compress%': '',
     'resource_input_paths': [],
     'intermediate_dir': '<(PRODUCT_DIR)/<(_target_name)',
     'asset_location%': '<(intermediate_dir)/assets',


### PR DESCRIPTION
Apk is actually a common zip file. Since Lite-17, the default
behavior of generating apk has been changed as not compressing
.dat .pak and .bin files. So,the final apk size is much bigger.

Take Lite for example, xwalk.pak file is ~800K, if we compress
it when generating apk, the final apk size is 500K smaller.