### PR TITLE
Windows: PageVisibility API when any other window goes fullscreen

### DIFF
--- a/ui/views/win/hwnd_message_handler.h
+++ b/ui/views/win/hwnd_message_handler.h
@@ -495,6 +495,10 @@ class VIEWS_EXPORT HWNDMessageHandler :
                           base::TimeDelta time_stamp,
                           TouchEvents* touch_events);
 
+  // Register for AppBar notification about other processes going fullscreen.
+  // |enable| true to register for notification, false to unregister.
+  void EnableFullscreenNotifications(bool enable);
+
   HWNDMessageHandlerDelegate* delegate_;
 
   scoped_ptr<FullscreenHandler> fullscreen_handler_;
@@ -530,6 +534,13 @@ class VIEWS_EXPORT HWNDMessageHandler :
 
   // The set of touch devices currently down.
   TouchIDs touch_ids_;
+
+  // An ID of custom message used to tTrack if fullscreen monitoring is enabled.
+  UINT fullscreen_notification_message_ = 0;
+
+  // Set to true when detected that it is this window that is going fullscreen.
+  // Used to avoid redundant showing the window when this window exits fullscreen.
+  bool this_window_went_fullscreen_ = false;
 
   // ScopedRedrawLock ----------------------------------------------------------
 


### PR DESCRIPTION
BUG=XWALK-5503

Some OSs (e.g. Windows and Linux) don't mark windows as hidden on screen
lock or when other opaque windows fully cover them.

The patch here targets Windows and window from any process going fullscreen.
For this, AppBar notifications are used.
Note that this covers e.g. VLC, MS Paint or browsers going fullscreen. It
doesn't cover screensaver or when application windows are maximized.

In the case when current window goes fullscreen, appbar notificaion is also
received. This case is handled, too.