### PR TITLE
Porting overscroll event to XWalkView and partially fix scrollTo method

### DIFF
--- a/content/browser/android/content_view_core_impl.cc
+++ b/content/browser/android/content_view_core_impl.cc
@@ -694,6 +694,14 @@ bool ContentViewCoreImpl::ShouldBlockMediaRequest(const GURL& url) {
                                                       j_url.obj());
 }
 
+void ContentViewCoreImpl::DidOverscroll(bool clampedX, bool clampedY) {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> j_obj = java_ref_.get(env);
+  if (!j_obj.is_null()) {
+    Java_ContentViewCore_didOverscroll(env, j_obj.obj(), clampedX, clampedY);
+  }
+}
+
 void ContentViewCoreImpl::DidStopFlinging() {
   JNIEnv* env = AttachCurrentThread();
 

--- a/content/browser/android/content_view_core_impl.h
+++ b/content/browser/android/content_view_core_impl.h
@@ -284,6 +284,8 @@ class ContentViewCoreImpl : public ContentViewCore,
 
   void DidStopFlinging();
 
+  void DidOverscroll(bool clampedX, bool clampedY);
+
   // Returns the context with which the ContentViewCore was created, typically
   // the Activity context.
   base::android::ScopedJavaLocalRef<jobject> GetContext() const;

--- a/content/browser/renderer_host/render_widget_host_view_android.cc
+++ b/content/browser/renderer_host/render_widget_host_view_android.cc
@@ -1768,6 +1768,10 @@ void RenderWidgetHostViewAndroid::DidOverscroll(
 
   if (overscroll_controller_)
     overscroll_controller_->OnOverscrolled(params);
+  
+  bool clampedX = params.latest_overscroll_delta.x() != 0 ? true : false;
+  bool clampedY = params.latest_overscroll_delta.y() != 0 ? true : false;
+  content_view_core_->DidOverscroll(clampedX, clampedY);
 }
 
 void RenderWidgetHostViewAndroid::DidStopFlinging() {

--- a/content/public/android/java/src/org/chromium/content/browser/ContentViewClient.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ContentViewClient.java
@@ -224,4 +224,10 @@ public class ContentViewClient {
     public int getDesiredHeightMeasureSpec() {
         return UNSPECIFIED_MEASURE_SPEC;
     }
+    
+    /**
+     * Called when overscroll event has been fired
+     **/
+    public void onOverScrolled(int scrollX, int scrollY, boolean clampedX, boolean clampedY) {
+    }
 }

--- a/content/public/android/java/src/org/chromium/content/browser/ContentViewCore.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ContentViewCore.java
@@ -3363,6 +3363,14 @@ public class ContentViewCore implements AccessibilityStateChangeListener, Screen
         mContextualSearchClient = contextualSearchClient;
     }
 
+    @CalledByNative
+    public void didOverscroll(boolean clampedX, boolean clampedY) {
+        mContentViewClient.onOverScrolled(mRenderCoordinates.getScrollXPixInt(),
+                                          mRenderCoordinates.getScrollYPixInt(),
+                                          clampedX, 
+                                          clampedY);
+    }
+
     private native long nativeInit(WebContents webContents, ViewAndroidDelegate viewAndroidDelegate,
             long windowAndroidPtr, HashSet<Object> retainedObjectSet);
     private static native ContentViewCore nativeFromWebContentsAndroid(WebContents webContents);

--- a/content/public/android/java/src/org/chromium/content/browser/ContentViewCore.java
+++ b/content/public/android/java/src/org/chromium/content/browser/ContentViewCore.java
@@ -1800,6 +1800,8 @@ public class ContentViewCore implements AccessibilityStateChangeListener, Screen
     public void scrollBy(float dxPix, float dyPix, boolean useLastFocalEventLocation) {
         if (mNativeContentViewCore == 0) return;
         if (dxPix == 0 && dyPix == 0) return;
+        mRenderCoordinates.setScrollX(mRenderCoordinates.getScrollXPix() + dxPix);
+        mRenderCoordinates.setScrollY(mRenderCoordinates.getScrollYPix() + dyPix);
         long time = SystemClock.uptimeMillis();
         // It's a very real (and valid) possibility that a fling may still
         // be active when programatically scrolling. Cancelling the fling in

--- a/content/public/android/java/src/org/chromium/content/browser/RenderCoordinates.java
+++ b/content/public/android/java/src/org/chromium/content/browser/RenderCoordinates.java
@@ -173,6 +173,24 @@ public class RenderCoordinates {
     }
 
     /**
+     * set scrollXCss from scrollTo method in ContentViewCore.
+     * @param scrollX value in css from scrollTo.
+     * TODO: This is work-around solution, if any better solution, deprecate it.
+     */
+    public void setScrollX(float scrollX) {
+        mScrollXCss = scrollX / mPageScaleFactor / mDeviceScaleFactor;
+    }
+
+    /**
+     * set scrollYCss from scrollTo method in ContentViewCore.
+     * @param scrollY value in css from scrollTo.
+     * TODO: This is work-around solution, if any better solution, deprecate it.
+     */
+    public void setScrollY(float scrollY) {
+        mScrollYCss = scrollY / mPageScaleFactor / mDeviceScaleFactor;
+    }
+
+    /**
      * @return Horizontal scroll offset in physical pixels.
      */
     public float getScrollXPix() {


### PR DESCRIPTION
These patch support the implementation of [PR-3605](https://github.com/crosswalk-project/crosswalk/pull/3605) in Crosswalk.