### PR TITLE
[Windows] Fix build.

### DIFF
--- a/third_party/WebKit/Source/core/css/CSSRule.h
+++ b/third_party/WebKit/Source/core/css/CSSRule.h
@@ -35,7 +35,7 @@ class CSSRuleList;
 class CSSStyleSheet;
 class StyleRuleBase;
 
-class CSSRule : public RefCountedWillBeGarbageCollectedFinalized<CSSRule>, public ScriptWrappable {
+class CORE_EXPORT CSSRule : public RefCountedWillBeGarbageCollectedFinalized<CSSRule>, public ScriptWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     virtual ~CSSRule() { }


### PR DESCRIPTION
Subclass was exported but not the base class. It triggers a warning
which stops the build.

Fixed upstream by CL https://codereview.chromium.org/1637273003