### PR TITLE
[Backport] PRESUBMIT: Determine checkperms.py's path using input_api.

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -670,7 +670,10 @@ def _CheckFilePermissions(input_api, output_api):
   """Check that all files have their permissions properly set."""
   if input_api.platform == 'win32':
     return []
-  args = [input_api.python_executable, 'tools/checkperms/checkperms.py',
+  checkperms_tool = input_api.os_path.join(
+      input_api.PresubmitLocalPath(),
+      'tools', 'checkperms', 'checkperms.py')
+  args = [input_api.python_executable, checkperms_tool,
           '--root', input_api.change.RepositoryRoot()]
   for f in input_api.AffectedFiles():
     args += ['--file', f.LocalPath()]


### PR DESCRIPTION
This commit allows us to turn on the file permission checks in Crosswalk's
`PRESUBMIT.py`.

Original commit message:
------------------------
Like _GetIDLParseError(), use input_api.PresubmitLocalPath() to
determine checkperms.py's full path instead of just using
"tools/checkperms/checkperms.py".

While the latter works just fine for Chromium, using an absolute path
helps downstreams that may use Chromium's PRESUBMIT checks in their own
files.

R=jochen@chromium.org,phajdan.jr@chromium.org

Review URL: https://codereview.chromium.org/1847373003