### PR TITLE
[WebCL] Enable GN build.

### DIFF
--- a/third_party/WebKit/Source/bindings/modules/v8/custom/custom.gni
+++ b/third_party/WebKit/Source/bindings/modules/v8/custom/custom.gni
@@ -8,5 +8,7 @@ bindings_modules_v8_custom_files =
                     "V8CustomSQLStatementErrorCallback.cpp",
                     "V8DeviceMotionEventCustom.cpp",
                     "V8ServiceWorkerMessageEventCustom.cpp",
+                    "V8WebCLCommandQueueCustom.cpp",
+                    "V8WebCLProgramCustom.cpp",
                   ],
                   "abspath")


### PR DESCRIPTION
This commit enables GN build of the WebCL module. Files for custom
bindings are the only ones that need to be added to GN
configuration. All other files of the WebCL module are imported from GYP
configurations automatically. The patch has been tested with a vanilla
Chromium + WebCL build.