### PR TITLE
[WebCL] Let WebCLEvent.prototype.getProfilingInfo() return 64-bit pro…

### DIFF
--- a/third_party/WebKit/Source/modules/webcl/WebCLEvent.h
+++ b/third_party/WebKit/Source/modules/webcl/WebCLEvent.h
@@ -27,7 +27,7 @@ public:
     static PassRefPtr<WebCLEvent> create();
 
     virtual ScriptValue getInfo(ScriptState*, unsigned, ExceptionState&);
-    unsigned getProfilingInfo(int, ExceptionState&);
+    virtual ScriptValue getProfilingInfo(ScriptState*, unsigned, ExceptionState&);
     void setCallback(unsigned, WebCLCallback*, ExceptionState&);
     void release() override;
 

--- a/third_party/WebKit/Source/modules/webcl/WebCLEvent.idl
+++ b/third_party/WebKit/Source/modules/webcl/WebCLEvent.idl
@@ -8,7 +8,7 @@ typedef unsigned long long CLulong;
     Constructor,
 ] interface WebCLEvent {
     [CallWith=ScriptState, RaisesException] any getInfo(CLenum name);
-    [RaisesException] CLulong getProfilingInfo(CLenum name);
+    [CallWith=ScriptState, RaisesException] any getProfilingInfo(CLenum name);
     [RaisesException] void setCallback(CLenum commandExecCallbackType,
                                        WebCLCallback notify);
     void release();


### PR DESCRIPTION
…filing info.

The profiling info of an event is a 64-bit value that describes the
current device time counter in nanoseconds
(https://www.khronos.org/registry/cl/sdk/1.1/docs/man/xhtml/clGetEventProfilingInfo.html),
but it was casted as a 32-bit integer in previous implementation, and
thus made the return value almost useless. I believe this is a typo in
the WebCL specification, and this commit fixes the problem.