### PR TITLE
Enable WebRTC with H264

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -96,7 +96,7 @@ deps = {
   'src/third_party/libexif/sources':
     (Var("chromium_git")) + '/chromium/deps/libexif/sources.git@045b7fb9aa6d9b7f1954db248caf5eefe917476d',
   'src/third_party/libjingle/source/talk':
-    (Var("chromium_git")) + '/external/webrtc/trunk/talk.git@4ce7fef091e1d63a3bfc2ed225619893b0eb1782',
+    (Var("chromium_git")) + '/external/webrtc/trunk/talk.git@13b4861d910ad67ff9fb10a2f865c72effe86060',
   'src/third_party/libjpeg_turbo':
     (Var("chromium_git")) + '/chromium/deps/libjpeg_turbo.git@e4e75037f29745f1546b6ebf5cf532e841c04c2c',
   'src/third_party/libphonenumber/src/phonenumbers':
@@ -152,7 +152,7 @@ deps = {
   'src/third_party/webpagereplay':
     (Var("chromium_git")) + '/external/github.com/chromium/web-page-replay.git@7564939bdf6482d57b9bd5e9c931679f96d8cf75',
   'src/third_party/webrtc':
-    (Var("chromium_git")) + '/external/webrtc/trunk/webrtc.git@24a16656da7249c0d836247bc77dbc475f71f0af',
+    (Var("chromium_git")) + '/external/webrtc/trunk/webrtc.git@65451bababb27efd7e7aae67b1441f4522634006',
   'src/third_party/yasm/source/patched-yasm':
     (Var("chromium_git")) + '/chromium/deps/yasm/patched-yasm.git@4671120cd8558ce62ee8672ebf3eb6f5216f909b',
   'src/tools/gyp':

--- a/android_webview/lib/main/aw_main_delegate.cc
+++ b/android_webview/lib/main/aw_main_delegate.cc
@@ -92,7 +92,6 @@ bool AwMainDelegate::BasicStartupComplete(int* exit_code) {
 #if defined(ENABLE_WEBRTC)
   cl->AppendSwitch(switches::kDisableWebRtcHWDecoding);
 #endif
-  cl->AppendSwitch(switches::kDisableAcceleratedVideoDecode);
 
   // This is needed for sharing textures across the different GL threads.
   cl->AppendSwitch(switches::kEnableThreadedTextureMailboxes);

--- a/content/browser/gpu/gpu_data_manager_impl_private.cc
+++ b/content/browser/gpu/gpu_data_manager_impl_private.cc
@@ -932,22 +932,8 @@ bool GpuDataManagerImplPrivate::ShouldDisableAcceleratedVideoDecode(
   if (group_name == "Disabled")
     return true;
 
-  // Accelerated decode is never available with --disable-gpu. It is also
-  // currently non-functional with --single-process and --in-process-gpu, but
-  // these should be fixable. We set the --disable-accelerated-video-decode flag
-  // in these cases so that the renderer can be aware. (Which is important on
-  // Android where there is no fallback once WMPI is selected.)
-  //
-  // TODO(sandersd): Enable support for accelerated decode with
-  // --in-process-gpu, at least on Android (necessary to support WebView).
-  // http://crbug.com/574935.
-  if (command_line->HasSwitch(switches::kDisableGpu) ||
-      command_line->HasSwitch(switches::kSingleProcess) ||
-      command_line->HasSwitch(switches::kInProcessGPU)) {
-    return true;
-  }
-
-  return false;
+  // Accelerated decode is never available with --disable-gpu.
+  return command_line->HasSwitch(switches::kDisableGpu);
 }
 
 void GpuDataManagerImplPrivate::GetDisabledExtensions(

--- a/content/gpu/gpu_child_thread.cc
+++ b/content/gpu/gpu_child_thread.cc
@@ -15,6 +15,7 @@
 #include "content/child/thread_safe_sender.h"
 #include "content/common/gpu/gpu_memory_buffer_factory.h"
 #include "content/common/gpu/gpu_messages.h"
+#include "content/common/gpu/media/gpu_video_decode_accelerator.h"
 #include "content/gpu/gpu_process_control_impl.h"
 #include "content/gpu/gpu_watchdog_thread.h"
 #include "content/public/common/content_client.h"
@@ -172,6 +173,11 @@ GpuChildThread::GpuChildThread(
              switches::kSingleProcess) ||
          base::CommandLine::ForCurrentProcess()->HasSwitch(
              switches::kInProcessGPU));
+
+  // Populate accelerator capabilities (normally done during GpuMain, which is
+  // not called for single process or in process gpu).
+  gpu_info_.video_decode_accelerator_capabilities =
+      content::GpuVideoDecodeAccelerator::GetCapabilities();
 
   if (!gfx::GLSurface::InitializeOneOff())
     VLOG(1) << "gfx::GLSurface::InitializeOneOff failed";

--- a/content/renderer/render_thread_impl.cc
+++ b/content/renderer/render_thread_impl.cc
@@ -1462,16 +1462,6 @@ media::GpuVideoAcceleratorFactories* RenderThreadImpl::GetGpuFactories() {
 
   const base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
 
-#if defined(OS_ANDROID)
-  if (SynchronousCompositorFactory::GetInstance()) {
-    if (!cmd_line->HasSwitch(switches::kDisableAcceleratedVideoDecode)) {
-      DLOG(WARNING) << "Accelerated video decoding is not explicitly disabled, "
-                       "but is not supported by in-process rendering";
-    }
-    return NULL;
-  }
-#endif
-
   scoped_refptr<base::SingleThreadTaskRunner> media_task_runner =
       GetMediaThreadTaskRunner();
   scoped_refptr<ContextProviderCommandBuffer> shared_context_provider =


### PR DESCRIPTION
1: Update webrtc and libjingle talk git to minimum version which enable h264 codec with build flag rtc_use_h264
2: Cherry-pick from chromium commit https://codereview.chromium.org/1641013002, enable accelerated video decoder in process gpu and single process
The feature could be verified with url https://apprtc.appspot.com/?debug=loopback&vsc=h264
BUG=XWALK-2310 XWALK-6627