### PR TITLE
[XDK] Add in-depth allocation tracker

### DIFF
--- a/third_party/WebKit/Source/core/inspector/InspectorHeapProfilerAgent.h
+++ b/third_party/WebKit/Source/core/inspector/InspectorHeapProfilerAgent.h
@@ -37,6 +37,7 @@
 #include "wtf/Noncopyable.h"
 #include "wtf/OwnPtr.h"
 #include "wtf/PassOwnPtr.h"
+#include <v8-profiler.h>
 
 namespace v8 {
 class Isolate;
@@ -73,9 +74,13 @@ public:
     void getHeapObjectId(ErrorString*, const String& objectId, String* heapSnapshotObjectId) override;
     void startSampling(ErrorString*) override;
     void stopSampling(ErrorString*, OwnPtr<protocol::HeapProfiler::SamplingHeapProfile>*) override;
+    void startTrackingHeapXDK(ErrorString*, const Maybe<int>& stack_depth, const Maybe<int>& sav, const Maybe<bool>& retentions) override;
+    void stopTrackingHeapXDK(ErrorString*, OwnPtr<protocol::HeapProfiler::HeapEventXDK>*) override;
 
 private:
     class HeapStatsUpdateTask;
+    class HeapXDKStream;
+    class HeapXDKUpdateTask;
 
     InspectorHeapProfilerAgent(v8::Isolate*, V8RuntimeAgent*);
 
@@ -85,6 +90,7 @@ private:
 
     OwnPtr<V8HeapProfilerAgent> m_v8HeapProfilerAgent;
     OwnPtr<HeapStatsUpdateTask> m_heapStatsUpdateTask;
+    OwnPtr<HeapXDKUpdateTask> m_heapXDKUpdateTask;
     v8::Isolate* m_isolate;
 };
 

--- a/third_party/WebKit/Source/devtools/front_end/sdk/HeapProfilerModel.js
+++ b/third_party/WebKit/Source/devtools/front_end/sdk/HeapProfilerModel.js
@@ -16,7 +16,8 @@ WebInspector.HeapProfilerModel.Events = {
     LastSeenObjectId: "LastSeenObjectId",
     AddHeapSnapshotChunk: "AddHeapSnapshotChunk",
     ReportHeapSnapshotProgress: "ReportHeapSnapshotProgress",
-    ResetProfiles: "ResetProfiles"
+    ResetProfiles: "ResetProfiles",
+    HeapXDKUpdate: "HeapXDKUpdate"
 }
 
 WebInspector.HeapProfilerModel.prototype = {
@@ -68,6 +69,14 @@ WebInspector.HeapProfilerModel.prototype = {
     resetProfiles: function()
     {
         this.dispatchEventToListeners(WebInspector.HeapProfilerModel.Events.ResetProfiles);
+    },
+
+    /**
+     * @param {string} message
+     */
+    heapXDKUpdate: function (message)
+    {
+        this.dispatchEventToListeners(WebInspector.HeapProfilerModel.Events.HeapXDKUpdate, message);
     },
 
     __proto__: WebInspector.SDKModel.prototype
@@ -129,5 +138,14 @@ WebInspector.HeapProfilerDispatcher.prototype = {
     resetProfiles: function()
     {
         this._heapProfilerModel.resetProfiles();
+    },
+
+    /**
+     * @override
+     * @param {string} message
+     */
+    heapXDKUpdate: function(message)
+    {
+        this._heapProfilerModel.heapXDKUpdate(message);
     }
 }

--- a/third_party/WebKit/Source/devtools/protocol.json
+++ b/third_party/WebKit/Source/devtools/protocol.json
@@ -4016,6 +4016,7 @@
                     { "name": "columnNumber", "type": "integer", "description": "1-based column number of the function start position." },
                     { "name": "hitCount", "type": "integer", "description": "Number of samples where this node was on top of the call stack." },
                     { "name": "callUID", "type": "number", "description": "Call UID." },
+                    { "name": "stackEntryLine", "type": "integer", "description": "Hit line for entry in stack." },
                     { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Child nodes." },
                     { "name": "deoptReason", "type": "string", "description": "The reason of being not optimized. The function may be deoptimized or marked as don't optimize."},
                     { "name": "id", "type": "integer", "description": "Unique id of the node." },
@@ -4120,6 +4121,19 @@
                 "properties": [
                     { "name": "head", "$ref": "SamplingHeapProfileNode" }
                 ]
+            },
+            {
+                "id": "HeapEventXDK",
+                "type": "object",
+                "description": "",
+                "properties": [
+                    { "name": "duration", "type": "integer" },
+                    { "name": "symbols", "type": "string" },
+                    { "name": "frames", "type": "string" },
+                    { "name": "types", "type": "string" },
+                    { "name": "chunks", "type": "string" },
+                    { "name": "retentions", "type": "string" }
+                ]
             }
         ],
         "commands": [
@@ -4141,6 +4155,20 @@
                     { "name": "reportProgress", "type": "boolean", "optional": true, "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped." }
                 ]
 
+            },
+            {
+                "name": "startTrackingHeapXDK",
+                "parameters": [
+                    { "name": "stack_depth", "type": "integer", "optional": true },
+                    { "name": "sav", "type": "integer", "optional": true },
+                    { "name": "retentions", "type": "boolean", "optional": true }
+                ]
+            },
+            {
+                "name": "stopTrackingHeapXDK",
+                "returns": [
+                   { "name": "profileXDK", "$ref": "HeapEventXDK", "description": "Recorded profile." }
+                ]
             },
             {
                 "name": "takeHeapSnapshot",
@@ -4218,6 +4246,16 @@
                 "description": "If heap objects tracking has been started then backend may send update for one or more fragments",
                 "parameters": [
                     { "name": "statsUpdate", "type": "array", "items": { "type": "integer" }, "description": "An array of triplets. Each triplet describes a fragment. The first integer is the fragment index, the second integer is a total count of objects for the fragment, the third integer is a total size of the objects for the fragment."}
+                ]
+            },
+            {
+                "name": "heapXDKUpdate",
+                "parameters": [
+                    { "name": "symbols", "type": "string" },
+                    { "name": "frames", "type": "string" },
+                    { "name": "types", "type": "string" },
+                    { "name": "chunks", "type": "string" },
+                    { "name": "retentions", "type": "string" }
                 ]
             }
         ]

--- a/third_party/WebKit/Source/platform/v8_inspector/V8ProfilerAgentImpl.cpp
+++ b/third_party/WebKit/Source/platform/v8_inspector/V8ProfilerAgentImpl.cpp
@@ -60,6 +60,7 @@ PassOwnPtr<protocol::Profiler::CPUProfileNode> buildInspectorObjectFor(v8::Isola
         .setColumnNumber(node->GetColumnNumber())
         .setHitCount(node->GetHitCount())
         .setCallUID(node->GetCallUid())
+        .setStackEntryLine(node->GetSrcLine())
         .setChildren(children.release())
         .setPositionTicks(positionTicks.release())
         .setDeoptReason(node->GetBailoutReason())

--- a/third_party/WebKit/Source/platform/v8_inspector/public/V8HeapProfilerAgent.h
+++ b/third_party/WebKit/Source/platform/v8_inspector/public/V8HeapProfilerAgent.h
@@ -19,6 +19,7 @@ public:
     virtual ~V8HeapProfilerAgent() { }
 
     virtual void requestHeapStatsUpdate() = 0;
+    virtual void requestHeapXDKUpdate() = 0;
 };
 
 } // namespace blink


### PR DESCRIPTION
This patch includes in-depth allocation tracker and extention of
protocol.json by stackEntryLine that is used for total time annotations in
CPU profiling.

Details of HeapProfiler: Three new commands were added by analogy with
Chrome DevTools allocation tracker. Start/Stop and Event which is sent by timer.
Command stopTrackingHeapXDK accepts three parameters: stack depth for unwinding,
Sample After Value - period of timer and a flag to collect retention
information or not. Event sends to the host currently collected data about
symbols/callstack/objects. Command stopTrackingHeapXDK returns the final
info witch is similar to Event passed format with one more parameter:
duration of the collection.

Basing on this info consumer can build allocation call tree for any period
of time, annotate source by self and total allocation mertics and annotate
allocation call tree by the objects, which retain other objects in the
memory.

BUG=XWALK-6778