### PR TITLE
[ICS Support] Remove ffmpeg from DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -79,8 +79,6 @@ deps = {
     (Var("chromium_git")) + '/external/colorama.git@799604a1041e9b3bc5d2789ecbd7e8db2e18e6b8',
   'src/third_party/dom_distiller_js/dist':
     (Var("chromium_git")) + '/external/github.com/chromium/dom-distiller-dist.git@e21fe06cb71327ec62431f823e783d7b02f97b26',
-  'src/third_party/ffmpeg':
-    (Var("chromium_git")) + '/chromium/third_party/ffmpeg.git@501a5c5db447ec2b0903551c011dfcbf6c5cd22f',
   'src/third_party/flac':
     (Var("chromium_git")) + '/chromium/deps/flac.git@2c4b86af352b23498315c016dc207e3fb2733fc0',
   'src/third_party/hunspell_dictionaries':


### PR DESCRIPTION
The original ffmpeg uses the system call "posix_memalign" that
doesn't exist on Android 4.0. To use modified ffmpeg code,remove
ffmpeg from chromium's DEPS and fetch forked repo through
crosswalk's DEPS.