### PR TITLE
[Lite] remove duplicate defined resources

### DIFF
--- a/ui/resources/ui_resources.grd
+++ b/ui/resources/ui_resources.grd
@@ -129,14 +129,12 @@
       <structure type="chrome_scaled_image" name="IDR_EASY_UNLOCK_UNLOCKED_PRESSED" file="common/easy_unlock_unlocked_pressed.png" />
       <structure type="chrome_scaled_image" name="IDR_FOLDER_CLOSED" file="common/folder_closed.png" />
       <structure type="chrome_scaled_image" name="IDR_FOLDER_CLOSED_RTL" file="common/folder_closed_rtl.png" />
-      <structure type="chrome_scaled_image" name="IDR_MENU_CHECK_CHECKED" file="common/menu_check.png" />
       <if expr="not is_macosx and not is_ios">
         <structure type="chrome_scaled_image" name="IDR_MENU_HIERARCHY_ARROW" file="common/menu_hierarchy_arrow.png" />
       </if>
       <if expr="is_macosx or is_ios">
         <structure type="chrome_scaled_image" name="IDR_MENU_HIERARCHY_ARROW" file="mac/menu_hierarchy_arrow.png" />
       </if>
-      <structure type="chrome_scaled_image" name="IDR_MENU_DROPARROW" file="cros/menu_droparrow.png" />
       <structure type="chrome_scaled_image" name="IDR_MESSAGE_CLOSE" file="common/message_close.png" />
       <if expr="toolkit_views or is_macosx or is_ios">
         <structure type="chrome_scaled_image" name="IDR_NOTIFICATION_ARROW" file="common/notification_arrow.png"/>


### PR DESCRIPTION
GYP complains when setting use_minimum_resource=0. Two resources are
duplicate defined: IDR_MENU_CHECK_CHECKED and IDR_MENU_DROPARROW.
That's because they have already been defined no matter use_minimum_resource
is switched on/off.

The definition inside the condition block for use_minimum_resource is removed. 
@PeterWangIntel @heke123 @halton 
