### PR TITLE
[Backport] Disable static_assert about TransmissionInfo size to pass debug build.

### DIFF
--- a/net/quic/quic_protocol.h
+++ b/net/quic/quic_protocol.h
@@ -1390,8 +1390,6 @@ struct NET_EXPORT_PRIVATE TransmissionInfo {
   // Non-empty if there is a listener for this packet.
   std::list<AckListenerWrapper> ack_listeners;
 };
-static_assert(sizeof(TransmissionInfo) <= 128,
-              "TODO(ianswett): Keep the TransmissionInfo size to a cacheline.");
 
 // Struct to store the pending retransmission information.
 struct PendingRetransmission {


### PR DESCRIPTION
Orignal commit message:
> Disable static_assert about TransmissionInfo size to pass debug build.
>
> R=rch@chromium.org
> BUG=590140
>
> Committed: https://crrev.com/0e72481a295461c7ff302503a984c1771e597b1e
> Cr-Commit-Position: refs/heads/master@{#388269}
>
> patch from issue 1902793002 at patchset 1 (http://crrev.com/1902793002#ps1)