### PR TITLE
M52: Fix blink_platform.gyp for Android build.

### DIFF
--- a/third_party/WebKit/Source/platform/blink_platform.gyp
+++ b/third_party/WebKit/Source/platform/blink_platform.gyp
@@ -388,6 +388,7 @@
       ['OS=="android"', {
         'sources/': [
           ['include', 'fonts/linux/FontPlatformDataLinux\\.cpp$'],
+          ['include', 'fonts/linux/FontRenderStyle\\.cpp$'],
         ],
       }],
     ],


### PR DESCRIPTION
FontRendererStyle was excluded.

Fixing https://codereview.chromium.org/1944993003/ issue that missed
FontRendererStyle.cpp in gyp file