### PR TITLE
Change locale path from "locales" to "locales/xwalk"

### DIFF
--- a/ui/base/ui_base_paths.cc
+++ b/ui/base/ui_base_paths.cc
@@ -37,6 +37,7 @@ bool PathProvider(int key, base::FilePath* result) {
         return false;
 #else
       cur = cur.Append(FILE_PATH_LITERAL("locales"));
+      cur = cur.Append(FILE_PATH_LITERAL("xwalk"));
 #endif
       create_dir = true;
       break;


### PR DESCRIPTION
Both Crosswalk and Chrome they place the en-US.pak into folder
"locales" in build of Linux and windows. Potientially there is
conflicts, so it's better to set Crosswalk's locale-path as
"locales/xwalk".