### PR TITLE
Add GN build support for crosswalk-linux

### DIFF
--- a/.gn
+++ b/.gn
@@ -311,4 +311,5 @@ exec_script_whitelist = [
   "//tools/gn/setup.cc",
   "//ui/accessibility/BUILD.gn",
   "//ui/views/BUILD.gn",
+  "//xwalk/build/version.gni",
 ]


### PR DESCRIPTION
As Chromium will deprecate GYP build system since M54, we need to enable
GN build support for Crosswalk as soon as possible.
Set xwalk as "extra_deps" to Chromium in xwalk/build/common.gni:
`root_extra_deps = [ "//xwalk:xwalk_builder" ]`