### PR TITLE
[Android] Make it possible to build content_shell_apk with GN.

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -2187,6 +2187,7 @@ if (is_android) {
       "android/java/src/org/chromium/base/ApiCompatibilityUtils.java",
       "android/java/src/org/chromium/base/ApkAssets.java",
       "android/java/src/org/chromium/base/ApplicationStatus.java",
+      "android/java/src/org/chromium/base/ApplicationStatusManager.java",
       "android/java/src/org/chromium/base/BaseChromiumApplication.java",
       "android/java/src/org/chromium/base/BaseSwitches.java",
       "android/java/src/org/chromium/base/BuildInfo.java",

--- a/build/config/features.gni
+++ b/build/config/features.gni
@@ -114,6 +114,10 @@ declare_args() {
   # Enable printing with print preview. It does not imply
   # enable_basic_printing. It's possible to build Chrome with preview only.
   enable_print_preview = !is_android && !is_chromecast && !is_ios
+
+  # Enable WebVR support by default on Android
+  # Still requires command line flag to access API
+  enable_webvr = is_android
 }
 
 # Additional dependent variables -----------------------------------------------
@@ -164,10 +168,6 @@ enable_chromevox_next = false
 
 # Use brlapi from brltty for braille display support.
 use_brlapi = is_chromeos
-
-# Enable WebVR support by default on Android
-# Still requires command line flag to access API
-enable_webvr = is_android
 
 enable_configuration_policy = !is_ios
 

--- a/content/public/android/BUILD.gn
+++ b/content/public/android/BUILD.gn
@@ -159,7 +159,6 @@ android_library("content_java") {
     "java/src/org/chromium/content/browser/crypto/CipherFactory.java",
     "java/src/org/chromium/content/browser/framehost/NavigationControllerImpl.java",
     "java/src/org/chromium/content/browser/input/AnimationIntervalProvider.java",
-    "java/src/org/chromium/content/browser/input/CardboardVRDevice.java",
     "java/src/org/chromium/content/browser/input/ChromiumBaseInputConnection.java",
     "java/src/org/chromium/content/browser/input/CursorAnchorInfoController.java",
     "java/src/org/chromium/content/browser/input/DateTimeChooserAndroid.java",
@@ -211,6 +210,7 @@ android_library("content_java") {
 
   if (enable_webvr) {
     deps += [ "//third_party/cardboard-java:cardboard-java" ]
+    java_files += [ "java-optional/src/org/chromium/content/browser/input/CardboardVRDevice.java" ]
   }
 }
 
@@ -295,7 +295,7 @@ generate_jni("content_jni_headers") {
   jni_package = "content"
 
   if (enable_webvr) {
-    sources += [ "//content/public/android/java/src/org/chromium/content/browser/input/CardboardVRDevice.java" ]
+    sources += [ "//content/public/android/java-optional/src/org/chromium/content/browser/input/CardboardVRDevice.java" ]
     public_deps = [
       "//third_party/cardboard-java:cardboard-java",
     ]


### PR DESCRIPTION
This pull request contains a few separate patches, all of which are required in order to be able to build the `content_shell_apk` target using GN with Crosswalk's local modifications on top of the upstream commits.

* "[Temp] Make |enable_webvr==false| work in GN" and "[Android] Add ApplicationStatusManager.java to the GN build" just add some new or moved files to the respective `BUILD.gn` files. Their commit messages indicate which commits they should be squashed into in the future.
* "[Backport] GN: Set |enable_webvr| in the declare_args() block" is a backport from a commit I landed upstream that makes it possible to override the value of `enable_webvr` (which we currently need to disable in Crosswalk).

Linux and Windows are out of the scope of this pull request: they will be handled separately in other PRs.

RELATED BUG=XWALK-3674
