### PR TITLE
[Backport] gn: Remove unnecessary v8 defaults

### DIFF
--- a/build_overrides/v8.gni
+++ b/build_overrides/v8.gni
@@ -9,8 +9,6 @@ if (is_android) {
 # TODO(sky): nuke this. Temporary while sorting out http://crbug.com/465456.
 enable_correct_v8_arch = false
 
-v8_use_external_startup_data = !is_ios
-
 # Turns on compiler optimizations in V8 in Debug build.
 v8_optimized_debug = true
 


### PR DESCRIPTION
This is necessary for us to be able to change the value of
v8_use_external_startup_data in Crosswalk.

**IMPORTANT**: In M52 we only get rid of v8_use_external_startup_data, as
https://codereview.chromium.org/2024833002/ does not apply cleanly on
M52's V8. This patch must be rewritten for M53 to contain the entire
upstream change.

See also: crosswalk-project/v8-crosswalk#164

Original commit message:
> Remove chromium defaults for v8_optimized_debug and
> v8_use_external_startup_data.
>
> This is not needed after v8 provides these defaults:
> https://codereview.chromium.org/2025803003/
> https://codereview.chromium.org/2024833002/
>
> It also interferes if somebody tries to override the gn args
> with a different value.
>
> BUG=chromium:616034
> TBR=alokp@chromium.org, brettw@chromium.org
>
> Committed: https://crrev.com/0fffeb2adaa3c284b760922c1aecce1516b998ce
> Review-Url: https://codereview.chromium.org/2058033002