### PR TITLE
[Backport] Change back to destroy the CDM synchronously

### DIFF
--- a/media/blink/cdm_session_adapter.cc
+++ b/media/blink/cdm_session_adapter.cc
@@ -26,26 +26,12 @@ namespace {
 const char kMediaEME[] = "Media.EME.";
 const char kDot[] = ".";
 const char kTimeToCreateCdmUMAName[] = "CreateCdmTime";
-
-void ReleaseCdm(scoped_refptr<MediaKeys> cdm) {
-  // |cdm| will be freed now.
-}
-
 }  // namespace
 
 CdmSessionAdapter::CdmSessionAdapter()
     : trace_id_(0), weak_ptr_factory_(this) {}
 
-CdmSessionAdapter::~CdmSessionAdapter() {
-  // Freeing |cdm_| may take a while, so post a task to do it asynchronously.
-  // Note that freeing the CDM will cause any unfullfilled promises to be
-  // rejected, and that needs to be done outside of blink gc (which most
-  // likely triggered our destruction).
-  if (cdm_) {
-    base::ThreadTaskRunnerHandle::Get()->PostTask(
-        FROM_HERE, base::Bind(&ReleaseCdm, cdm_));
-  }
-}
+CdmSessionAdapter::~CdmSessionAdapter() {}
 
 void CdmSessionAdapter::CreateCdm(
     CdmFactory* cdm_factory,

--- a/third_party/WebKit/Source/modules/encryptedmedia/ContentDecryptionModuleResultPromise.h
+++ b/third_party/WebKit/Source/modules/encryptedmedia/ContentDecryptionModuleResultPromise.h
@@ -45,12 +45,16 @@ protected:
         m_resolver.clear();
     }
 
-    // Rejects the promise with a DOMException.
+    // Rejects the promise with a DOMException. This will post a task to
+    // actually reject the promise later on.
     void reject(ExceptionCode, const String& errorMessage);
 
     ExecutionContext* getExecutionContext() const;
 
 private:
+    // Rejects the promise with a DOMException.
+    void rejectInternal(ExceptionCode, const String& errorMessage);
+
     Member<ScriptPromiseResolver> m_resolver;
 };
 


### PR DESCRIPTION
Outstanding promises may get rejected due to blink garbage collection
destroying all the remaining EME objects when they are no longer
referenced. The original fix destroyed the CDM asynchronously.
However, that causes problems as the CDM may hold references to
objects owned by RenderFrameImpl, and they may get accessed after
~RenderFrameImpl.

This fix posts a task to reject the promise asynchronously. That way
any outstanding promises that need to be rejected are handled after
gc is done. It affects all EME promise rejections (from Chromium).

Resolving promises is still done synchronously as there may be events
already posted that need to happen only after the promise is resolved.

BUG=597355
TEST=existing EME tests still pass

Review-Url: https://codereview.chromium.org/1987883002

BUG=XWALK-7221