### PR TITLE
Remove unused private field device_position_

### DIFF
--- a/content/renderer/media/renderer_webaudiodevice_impl.h
+++ b/content/renderer/media/renderer_webaudiodevice_impl.h
@@ -91,8 +91,6 @@ class RendererWebAudioDeviceImpl
   // period of silence. We do this on android to save battery consumption.
   base::CancelableClosure start_null_audio_sink_callback_;
 
-  media::StreamPosition device_position_;
-
   // Security origin, used to check permissions for |output_device_|.
   url::Origin security_origin_;
 


### PR DESCRIPTION
../../content/renderer/media/renderer_webaudiodevice_impl.h:94:25: error: private field 'device_position_' is not used
  media::StreamPosition device_position_;
                        ^