### PR TITLE
[Temp] Declare v8_use_external_startup_data in build_overrides/v8.gni

### DIFF
--- a/build_overrides/v8.gni
+++ b/build_overrides/v8.gni
@@ -6,6 +6,10 @@ if (is_android) {
   import("//build/config/android/config.gni")
 }
 
+declare_args() {
+  v8_use_external_startup_data = !is_ios
+}
+
 # TODO(sky): nuke this. Temporary while sorting out http://crbug.com/465456.
 enable_correct_v8_arch = false
 


### PR DESCRIPTION
This is the Chromium side of crosswalk-project/v8-crosswalk#166.

Kind of revert 0908bc7 ("[Backport] gn: Remove unnecessary v8 defaults")
in the sense that `v8_use_external_startup_data` is being declared in
build_overrides/v8.gni again, but it is now enclosed in a `declare_args`
block.

We cannot just get rid of it as intended in 0908bc7, as M52's V8 does
not contain `gni/v8.gni` and a lot of declarations are done in V8's
top-level `BUILD.gn` instead.

Once we move to M53, V8 will work as intended and we will only need to
properly backport https://codereview.chromium.org/2058033002 to
chromium-crosswalk.