### PR TITLE
next: Rebase patch controlling the WebVR build

### DIFF
--- a/content/public/android/BUILD.gn
+++ b/content/public/android/BUILD.gn
@@ -40,7 +40,6 @@ android_library("content_java") {
     "//device/usb:java",
     "//device/vibration:mojo_bindings_java",
     "//device/vibration/android:vibration_manager_android",
-    "//device/vr:java",
     "//media/base/android:media_java",
     "//media/capture/video/android:capture_java",
     "//media/midi:midi_java",
@@ -56,6 +55,10 @@ android_library("content_java") {
 
     #"//content:content_common",
   ]
+
+  if (enable_webvr) {
+    deps += [ "//device/vr:java" ]
+  }
 
   srcjar_deps = [
     ":common_aidl",

--- a/device/BUILD.gn
+++ b/device/BUILD.gn
@@ -63,7 +63,6 @@ test("device_unittests") {
     "nfc/nfc_chromeos_unittest.cc",
     "nfc/nfc_ndef_record_unittest.cc",
     "test/run_all_unittests.cc",
-    "vr/vr_device_manager_unittest.cc",
   ]
 
   deps = [
@@ -76,9 +75,6 @@ test("device_unittests") {
     "//device/gamepad:test_helpers",
     "//device/nfc",
     "//device/power_save_blocker",
-    "//device/vr",
-    "//device/vr:fakes",
-    "//device/vr:mojo_bindings",
     "//mojo/common",
     "//mojo/edk/system",
     "//mojo/public/cpp/bindings",
@@ -219,6 +215,15 @@ test("device_unittests") {
       "bluetooth/bluetooth_classic_win_fake.h",
       "bluetooth/bluetooth_low_energy_win_fake.cc",
       "bluetooth/bluetooth_low_energy_win_fake.h",
+    ]
+  }
+
+  if (enable_webvr) {
+    sources += [ "vr/vr_device_manager_unittest.cc" ]
+    deps += [
+      "//device/vr",
+      "//device/vr:fakes",
+      "//device/vr:mojo_bindings",
     ]
   }
 }


### PR DESCRIPTION
This patch set first reverts "[Temp] Make |enable_webvr==false| work in GN" (see my comment in accdb96d922d789bf8204ff4ca1af87d09673c90) and later implements the same thing in the right files.

You can get rid of both the first commit and accdb96d922d789bf8204ff4ca1af87d09673c90, as only "[Temp] Only depend on deviecs/vr when enable_webvr is on" is required in M53.