### PR TITLE
[Backport][Windows] Pass "/MD" and variants outside the "runtime_library" target

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -461,6 +461,7 @@ _native_compiler_configs = [
 ]
 if (is_win) {
   _native_compiler_configs += [
+    "//build/config/win:default_crt",
     "//build/config/win:lean_and_mean",
     "//build/config/win:nominmax",
     "//build/config/win:unicode",

--- a/build/config/win/BUILD.gn
+++ b/build/config/win/BUILD.gn
@@ -186,33 +186,6 @@ config("runtime_library") {
     # However it is prohibited when using /analyze
     defines += [ "_USING_V110_SDK71_" ]
   }
-
-  if (is_component_build) {
-    # Component mode: dynamic CRT. Since the library is shared, it requires
-    # exceptions or will give errors about things not matching, so keep
-    # exceptions on.
-    if (is_debug) {
-      cflags += [ "/MDd" ]
-    } else {
-      cflags += [ "/MD" ]
-    }
-  } else {
-    if (current_os != "win") {
-      # WindowsRT: use the dynamic CRT.
-      if (is_debug) {
-        cflags += [ "/MDd" ]
-      } else {
-        cflags += [ "/MD" ]
-      }
-    } else {
-      # Desktop Windows: static CRT.
-      if (is_debug) {
-        cflags += [ "/MTd" ]
-      } else {
-        cflags += [ "/MT" ]
-      }
-    }
-  }
 }
 
 # Sets the default Windows build version. This is separated because some
@@ -287,6 +260,44 @@ config("common_linker_setup") {
     "/DELAYLOAD:shell32.dll",
     "/DELAYLOAD:uxtheme.dll",
   ]
+}
+
+# CRT --------------------------------------------------------------------------
+
+# Configures how the runtime library (CRT) is going to be used.
+# See https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx for a reference of
+# what each value does.
+config("default_crt") {
+  if (is_component_build) {
+    # Component mode: dynamic CRT. Since the library is shared, it requires
+    # exceptions or will give errors about things not matching, so keep
+    # exceptions on.
+    configs = [ ":dynamic_crt" ]
+  } else {
+    if (current_os != "win") {
+      # WindowsRT: use the dynamic CRT.
+      configs = [ ":dynamic_crt" ]
+    } else {
+      # Desktop Windows: static CRT.
+      configs = [ ":static_crt" ]
+    }
+  }
+}
+
+config("dynamic_crt") {
+  if (is_debug) {
+    cflags = [ "/MDd" ]
+  } else {
+    cflags = [ "/MD" ]
+  }
+}
+
+config("static_crt") {
+  if (is_debug) {
+    cflags = [ "/MTd" ]
+  } else {
+    cflags = [ "/MT" ]
+  }
 }
 
 # Subsystem --------------------------------------------------------------------


### PR DESCRIPTION
This patch is required for the .NET extension bridge to be built.

RELATED BUG=XWALK-7336

> Create separate configurations for passing "/MD", "/MT" and their debug
> variants: "dynamic_crt" passes "/MD" and "/MDd", whereas "static_crt"
> passes "/MT" and "/MTd". BUILDCONFIG then depends on "default_crt",
> which has some logic to choose whether to use either dynamic_crt or
> static_crt.
>
> The main reason behind this is to allow users to config -= the
> "default_crt" config: in gyp, it was possible to configure what was
> going to be passed to the compiler via the
> "win_{release,debug}_RuntimeLibrary" variable, which was useful when
> building code that needs to pass "/CLR", as it requires "/MD" and does
> not work with "/MT".
>
> R=brettw@chromium.org,dpranke@chromium.org,scottmg@chromium.org
>
> Review-Url: https://codereview.chromium.org/2379573003