### PR TITLE
[Windows] GN: Add missing RSSDK files in media/.

### DIFF
--- a/media/capture/BUILD.gn
+++ b/media/capture/BUILD.gn
@@ -6,6 +6,11 @@ import("//build/config/features.gni")
 import("//media/media_options.gni")
 import("//testing/test.gni")
 
+declare_args() {
+  # Windows: whether to use Intel's RealSense SDK for video capture.
+  use_rssdk = false
+}
+
 source_set("capture") {
   sources = [
     "content/animated_content_sampler.cc",
@@ -128,6 +133,20 @@ source_set("capture") {
       "/DELAYLOAD:mfplat.dll",
       "/DELAYLOAD:mfreadwrite.dll",
     ]
+
+    if (use_rssdk) {
+      defines = [ "USE_RSSDK" ]
+      deps += [ "//third_party/libpxc" ]
+      sources += [
+        "video/win/video_capture_device_rs_win.cc",
+        "video/win/video_capture_device_rs_win.h",
+      ]
+    } else {
+      sources += [
+        "video/win/video_capture_device_rs_win_null.cc",
+        "video/win/video_capture_device_rs_win_null.h",
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
This commit should be squashed into "[Windows] Support RealSense
Cameras" in the future. It simply does the same thing in GN: a new
argument `use_rssdk` has been added (defaulting to `false`) and takes
care of selecting which RSSDK files to include.

This is an improved version of a patch originally written by Ke He
<ke.he@intel.com>.