### PR TITLE
crosswalk-22: Fix the build after e762df3

### DIFF
--- a/content/renderer/media/renderer_webaudiodevice_impl.h
+++ b/content/renderer/media/renderer_webaudiodevice_impl.h
@@ -89,8 +89,6 @@ class RendererWebAudioDeviceImpl
   // period of silence. We do this on android to save battery consumption.
   base::CancelableClosure start_null_audio_sink_callback_;
 
-  media::StreamPosition device_position_;
-
   // Security origin, used to check permissions for |output_device_|.
   url::Origin security_origin_;
 


### PR DESCRIPTION
Remove a stray line that should have been removed in e762df3 ("Revert
AudioDestinationNode.devicePosition commits"). It was preventing the
build from succeeding.

RELATED BUG=XWALK-7030
RELATED BUG=XWALK-7226