### PR TITLE
Support Crosswalk and Android System WebView in the same application

### DIFF
--- a/base/i18n/icu_util.cc
+++ b/base/i18n/icu_util.cc
@@ -86,6 +86,11 @@ void LazyInitIcuDataFile() {
   if (g_icudtl_pf != kInvalidPlatformFile) {
     return;
   }
+//It's not correct to check and read from assets folder first, since xwalk
+//put icudtl.dat in other folders like res/raw instead of assets.Reading
+//from assets has a risk of conflict with android system webview.
+//See https://crosswalk-project.org/jira/browse/XWALK-7004
+#if 0
 #if defined(OS_ANDROID)
   int fd = base::android::OpenApkAsset(kAndroidAssetsIcuDataFileName,
                                        &g_icudtl_region);
@@ -95,6 +100,7 @@ void LazyInitIcuDataFile() {
   }
 // For unit tests, data file is located on disk, so try there as a fallback.
 #endif  // defined(OS_ANDROID)
+#endif
 #if !defined(OS_MACOSX)
   FilePath data_path;
 #if defined(OS_WIN)


### PR DESCRIPTION
xwalk will put icudtl.dat in different folder like raw/res instead of
assets.So it's not right to check and read from assets/icudtl.dat in
high priority.Otherwise when android webview is called , app will
extract webview.apk and copy it's icudtl.dat to assets,hence the two
icudtl.dat will conflict.

BUG=XWALK-7004